### PR TITLE
simplify ast parsing logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "json-parser"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 displaydoc = "0.2.5"

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum Error {
     ExpectedKeyOrClosing(Token),
     /// expected comma or closing brace, found {0:?}
     ExpectedCommaOrClosing(Token),
+    /// expected opening curly brace, found {0:?}
+    ExpectedOpening(Token),
     /// {0}
     Custom(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod tokens;
 use error::{Error, Result};
 
 use crate::{
-    ast::{parse_str, Value},
+    ast::{Value, parse_str},
     tokens::NULL,
 };
 


### PR DESCRIPTION
- **handle expected colon**
- **expected value**
- **simplify init error handling**
- **expected key or closing error**
- **Expected comma or closing**
- **Add token context to Expected key error**
- **update todos with more error handling tasks**
- **Remove duplicate test**
- **pass hashmap through instead of panicing in an invalid state**
- **split out object parsing logic**
- **Rename Object State variants**
