### PR TITLE
stringify perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstream",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 keywords = ["parser", "formatter", "json", "linter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 authors = ["Jacob Asper <jacobasper191@gmail.com>"]
 keywords = ["parser", "formatter", "json", "linter"]

--- a/justfile
+++ b/justfile
@@ -47,3 +47,7 @@ prepublish:
 release-binary:
     release-plz update
     cargo release --no-publish --tag-prefix=jjpwrgem- --execute
+
+# preview release notes
+release-notes:
+    dist host --steps=create --output-format=json | jq -r .announcement_github_body


### PR DESCRIPTION
- **perf: write to single buffer instead of allocating buffer per JSON value**
- **chore: release-notes-preview command**
- **perf: join_into utility to declaritively avoid allocating delimiter strings**
