### PR TITLE
chore: enable nightly rustfmt with doc comment and import formatting

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,10 +18,14 @@ env:
 jobs:
   format:
     runs-on: ubuntu-latest
+    env:
+      TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v6
       - name: update rust
         run: rustup update ${{ env.TOOLCHAIN }} && rustup default ${{ env.TOOLCHAIN }}
+      - name: install rustfmt for nightly
+        run: rustup component add rustfmt --toolchain ${{ env.TOOLCHAIN }}
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Configure Dependency Caching
@@ -38,7 +42,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: update rust
         run: rustup update ${{ env.TOOLCHAIN }} && rustup default ${{ env.TOOLCHAIN }}
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v4
         with:
           version: 10
           run_install: true
@@ -87,7 +91,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: build
         run: just vscode-bin
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v4
         with:
           version: 10
           run_install: true

--- a/crates/cli/main.rs
+++ b/crates/cli/main.rs
@@ -1,20 +1,22 @@
 mod commands;
 mod error;
 mod output;
-pub use error::{Error, Result};
+
+use std::{
+    io::{IsTerminal, Read},
+    process::ExitCode,
+};
 
 use clap::Parser;
+pub use error::{Error, Result};
 use jjpwrgem_parse::{
     error::diagnostics::{self, Diagnostic, Source},
     format::{self, LineEnding},
     validate_str,
 };
 use jjpwrgem_ui::{Color, Style};
-use std::io::{IsTerminal, Read};
-use std::process::ExitCode;
 
-use crate::commands::Commands;
-use crate::output::Output;
+use crate::{commands::Commands, output::Output};
 
 fn main() -> ExitCode {
     let cli = commands::Cli::parse();

--- a/crates/cli/output.rs
+++ b/crates/cli/output.rs
@@ -1,7 +1,8 @@
 use core::fmt::Debug;
+use std::process::ExitCode;
+
 use jjpwrgem_parse::error::diagnostics::Diagnostic;
 use jjpwrgem_ui::Style;
-use std::process::ExitCode;
 
 pub struct Output {
     pub stdout: Option<String>,

--- a/crates/parse/src/ast.rs
+++ b/crates/parse/src/ast.rs
@@ -1,6 +1,8 @@
-use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
 use std::borrow::Cow;
+
 use visitor::AstVisitor;
+
+use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
 
 #[derive(Debug, Clone, Default, Eq)]
 pub struct ObjectEntries<'a>(pub Vec<(&'a str, Value<'a>)>);
@@ -62,11 +64,12 @@ pub fn parse_str<'a>(json: &'a str) -> Result<'a, Value<'a>> {
 }
 
 mod visitor {
+    use std::borrow::Cow;
+
     use crate::{
         ast::{ObjectEntries, Value},
         traverse::Visitor,
     };
-    use std::borrow::Cow;
 
     #[derive(Debug, Default)]
     pub struct AstVisitor<'a> {

--- a/crates/parse/src/error.rs
+++ b/crates/parse/src/error.rs
@@ -1,12 +1,17 @@
 pub mod diagnostics;
 
-use crate::tokens::CharWithContext;
-use crate::tokens::lexical::trim_end_whitespace;
-use crate::tokens::{JsonCharOption, Token, TokenOption, TokenWithContext, lexical::JsonChar};
-use core::fmt::Display;
-use core::ops::{Deref, Range};
+use core::{
+    fmt::Display,
+    ops::{Deref, Range},
+};
+
 use displaydoc::Display;
 use thiserror::Error;
+
+use crate::tokens::{
+    CharWithContext, JsonCharOption, Token, TokenOption, TokenWithContext,
+    lexical::{JsonChar, trim_end_whitespace},
+};
 
 pub type Result<'a, T> = std::result::Result<T, Error<'a>>;
 

--- a/crates/parse/src/error/diagnostics.rs
+++ b/crates/parse/src/error/diagnostics.rs
@@ -1,9 +1,10 @@
+use core::ops::Range;
+use std::{borrow::Cow, path::Path};
+
 use crate::{
     Error, ErrorKind,
     tokens::{JsonCharOption, Token, TokenOption, TokenWithContext, lexical::JsonChar},
 };
-use core::ops::Range;
-use std::{borrow::Cow, path::Path};
 pub const EXPECTED_COMMA_OR_CLOSED_CURLY_MESSAGE: &str = "the preceding key/value pair";
 pub const INSERT_MISSING_CLOSED_BRACE_HELP: &str = "insert the missing closed brace";
 

--- a/crates/parse/src/format.rs
+++ b/crates/parse/src/format.rs
@@ -3,9 +3,10 @@ mod prettify;
 pub mod serde;
 mod uglify;
 
-use crate::tokens::{FALSE, NULL, TRUE};
 pub use prettify::{FormatOptions, format_str, format_value, prettify_str, prettify_value};
 pub use uglify::{uglify_str, uglify_value};
+
+use crate::tokens::{FALSE, NULL, TRUE};
 
 /// writes formatted delimiters between formatted items
 ///
@@ -16,7 +17,9 @@ pub use uglify::{uglify_str, uglify_value};
 /// # use std::fmt::Write as _;
 ///
 /// let mut buf = String::new();
-/// join_into(&mut buf, [1,2,3,4],
+/// join_into(
+///     &mut buf,
+///     [1, 2, 3, 4],
 ///     |buf, x| write!(buf, "{}", x * 2).unwrap(),
 ///     |buf, _| write!(buf, ",").unwrap(),
 /// );

--- a/crates/parse/src/format/prettify.rs
+++ b/crates/parse/src/format/prettify.rs
@@ -124,7 +124,9 @@ pub fn format_str<'a>(
 /// # use std::fmt::Write as _;
 ///
 /// let mut buf = String::new();
-/// join_into(&mut buf, [1,2,3,4],
+/// join_into(
+///     &mut buf,
+///     [1, 2, 3, 4],
 ///     |buf, x| write!(buf, "{}", x * 2).unwrap(),
 ///     |buf, _| write!(buf, ",").unwrap(),
 /// );

--- a/crates/parse/src/format/serde.rs
+++ b/crates/parse/src/format/serde.rs
@@ -50,10 +50,12 @@ pub fn uglify_value(val: serde_json::Value) -> String {
 /// ```
 /// # use std::collections::HashMap;
 /// # use jjpwrgem_parse::format::serde::uglify_serializable;
-/// let map: HashMap<String, String> = HashMap::from([
-///     ("rust is a must".to_string(), "🦀".to_string()),
-/// ]);
-/// assert_eq!(uglify_serializable(map).unwrap(), r#"{"rust is a must":"🦀"}"#);
+/// let map: HashMap<String, String> =
+///     HashMap::from([("rust is a must".to_string(), "🦀".to_string())]);
+/// assert_eq!(
+///     uglify_serializable(map).unwrap(),
+///     r#"{"rust is a must":"🦀"}"#
+/// );
 /// ```
 pub fn uglify_serializable(val: impl serde::Serialize) -> serde_json::Result<String> {
     Ok(uglify_value(serde_json::to_value(val)?))
@@ -90,13 +92,15 @@ pub fn prettify_value(
 /// # use std::collections::HashMap;
 /// # use jjpwrgem_parse::format::LineEnding;
 /// # use jjpwrgem_parse::format::serde::prettify_serializable;
-/// let map: HashMap<String, String> = HashMap::from([
-///     ("rust is a must".to_string(), "🦀".to_string()),
-/// ]);
+/// let map: HashMap<String, String> =
+///     HashMap::from([("rust is a must".to_string(), "🦀".to_string())]);
 /// let expected = r#"{
 ///   "rust is a must": "🦀"
 /// }"#;
-/// assert_eq!(prettify_serializable(map, 80, LineEnding::Lf).unwrap(), expected);
+/// assert_eq!(
+///     prettify_serializable(map, 80, LineEnding::Lf).unwrap(),
+///     expected
+/// );
 /// ```
 pub fn prettify_serializable(
     val: impl serde::Serialize,
@@ -119,9 +123,8 @@ pub fn prettify_serializable(
 /// # use std::collections::HashMap;
 /// # use jjpwrgem_parse::format::{FormatOptions, LineEnding};
 /// # use jjpwrgem_parse::format::serde::format_serializable;
-/// let map: HashMap<String, String> = HashMap::from([
-///     ("rust is a must".to_string(), "🦀".to_string()),
-/// ]);
+/// let map: HashMap<String, String> =
+///     HashMap::from([("rust is a must".to_string(), "🦀".to_string())]);
 /// let out = format_serializable(map, FormatOptions::prettify(LineEnding::Lf), 80).unwrap();
 /// let expected = r#"{
 ///   "rust is a must": "🦀"

--- a/crates/parse/src/format/uglify.rs
+++ b/crates/parse/src/format/uglify.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     Result,
     ast::Value,
@@ -5,7 +7,6 @@ use crate::{
     tokens::TokenStream,
     traverse::{Visitor, parse_tokens, parse_value},
 };
-use std::borrow::Cow;
 
 pub fn uglify_str(json: &str) -> Result<'_, String> {
     let mut visitor = UglifyEmitVisitor::default();

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -5,5 +5,6 @@ pub mod format;
 pub mod tokens;
 mod traverse;
 
-pub use crate::error::{Error, ErrorKind, Result};
 pub use check::validate_str;
+
+pub use crate::error::{Error, ErrorKind, Result};

--- a/crates/parse/src/tokens.rs
+++ b/crates/parse/src/tokens.rs
@@ -3,10 +3,12 @@ mod number;
 mod stream;
 mod string;
 
-use crate::tokens::lexical::JsonChar;
 use core::{fmt::Display, ops::Range};
 use std::borrow::Cow;
+
 pub use stream::TokenStream;
+
+use crate::tokens::lexical::JsonChar;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token<'a> {
@@ -170,9 +172,8 @@ impl From<f64> for Token<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Error, ErrorKind, Result};
-
     use super::*;
+    use crate::{Error, ErrorKind, Result};
 
     fn str_to_tokens<'a>(s: &'a str) -> Result<'a, Vec<TokenWithContext<'a>>> {
         stream::TokenStream::new(s).collect()

--- a/crates/parse/src/tokens/lexical.rs
+++ b/crates/parse/src/tokens/lexical.rs
@@ -100,8 +100,9 @@ impl From<char> for JsonChar {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use rstest::rstest;
+
+    use super::*;
 
     #[rstest]
     #[case('\u{0008}', r"\b")]

--- a/crates/parse/src/tokens/stream.rs
+++ b/crates/parse/src/tokens/stream.rs
@@ -1,11 +1,12 @@
 use core::{iter::Peekable, str::CharIndices};
 
-use crate::tokens::{
-    CharWithContext, Token, TokenWithContext, lexical::JsonChar, number::parse_num,
-    string::parse_string,
+use crate::{
+    Error, ErrorKind, Result,
+    tokens::{
+        CharWithContext, FALSE, NULL, TRUE, Token, TokenWithContext, lexical::JsonChar,
+        number::parse_num, string::parse_string,
+    },
 };
-use crate::tokens::{FALSE, NULL, TRUE};
-use crate::{Error, ErrorKind, Result};
 
 #[derive(Debug, Clone)]
 struct CharsWithContext<'a> {

--- a/crates/parse/src/tokens/string.rs
+++ b/crates/parse/src/tokens/string.rs
@@ -1,9 +1,10 @@
+use core::ops::Range;
+use std::iter::Peekable;
+
 use crate::{
     Error, ErrorKind, Result,
     tokens::{CharWithContext, JsonChar, Token, TokenWithContext},
 };
-use core::ops::Range;
-use std::iter::Peekable;
 
 enum StringState<'a> {
     Open,

--- a/crates/parse/src/traverse.rs
+++ b/crates/parse/src/traverse.rs
@@ -1,14 +1,15 @@
 mod array;
 mod object;
 
+use core::ops::Range;
+use std::borrow::Cow;
+
 use crate::{
     Error, ErrorKind, Result,
     ast::{ObjectEntries, Value},
     tokens::{Token, TokenStream, TokenWithContext},
     traverse::{array::parse_array, object::parse_object},
 };
-use core::ops::Range;
-use std::borrow::Cow;
 
 pub trait Visitor<'a> {
     fn on_object_open(&mut self);

--- a/crates/parse/src/traverse/array.rs
+++ b/crates/parse/src/traverse/array.rs
@@ -1,9 +1,10 @@
+use std::ops::Range;
+
 use crate::{
     error::{Error, ErrorKind, Result},
     tokens::{Token, TokenStream, TokenWithContext},
     traverse::{Visitor, parse_tokens, validate_start_of_value},
 };
-use std::ops::Range;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ArrayState<'a> {

--- a/crates/parse/src/traverse/object.rs
+++ b/crates/parse/src/traverse/object.rs
@@ -1,9 +1,10 @@
+use core::ops::Range;
+
 use crate::{
     Error, ErrorKind, Result,
     tokens::{Token, TokenOption, TokenStream, TokenWithContext},
     traverse::{Visitor, parse_tokens, validate_start_of_value},
 };
-use core::ops::Range;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 enum ObjectState<'a> {

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,7 +1,7 @@
-use crate::message::BasicErrorMessage;
 use annotate_snippets::{Renderer, renderer::DecorStyle};
-
 pub use jjpwrgem_parse::error::diagnostics::Diagnostic;
+
+use crate::message::BasicErrorMessage;
 
 mod pretty;
 

--- a/crates/ui/src/pretty.rs
+++ b/crates/ui/src/pretty.rs
@@ -57,8 +57,9 @@ mod diagnostic {
 }
 
 mod message {
-    use crate::message::BasicErrorMessage;
     use annotate_snippets::{Group, Level};
+
+    use crate::message::BasicErrorMessage;
 
     pub fn report_message<'a>(message: BasicErrorMessage) -> Vec<Group<'a>> {
         let error = Some(Level::ERROR.primary_title(message.error));

--- a/justfile
+++ b/justfile
@@ -13,12 +13,12 @@ prettier_glob := "./**/*.{md,yaml,yml,ts,js}"
 
 # format rust, justfile, and markdown
 format:
-    cargo fmt --all
+    cargo +nightly fmt --all
     just --fmt --unstable
     npx -y prettier {{ prettier_glob }} --write
 
 format-check:
-    cargo fmt --all -- --check
+    cargo +nightly fmt --all -- --check
     just --fmt --unstable --check
     npx -y prettier {{ prettier_glob }} --check
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+format_code_in_doc_comments = true
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+

--- a/tests/integration/commands/check.rs
+++ b/tests/integration/commands/check.rs
@@ -1,8 +1,10 @@
-use crate::common::cli;
-use crate::common::exec_cmd;
-use crate::test_json::*;
 use insta::assert_snapshot;
 use rstest::rstest;
+
+use crate::{
+    common::{cli, exec_cmd},
+    test_json::*,
+};
 
 #[rstest]
 #[case(crate::fixture_tuple!(OBJECT_MISSING_COLON_WITH_COMMA))]

--- a/tests/integration/commands/format.rs
+++ b/tests/integration/commands/format.rs
@@ -1,6 +1,9 @@
-use crate::common::{cli, exec_cmd, format_template};
-use crate::test_json::*;
 use insta::assert_snapshot;
+
+use crate::{
+    common::{cli, exec_cmd, format_template},
+    test_json::*,
+};
 
 #[rstest_reuse::apply(format_template)]
 fn prettify(#[case] (name, input): (&str, &str)) {

--- a/tests/integration/commands/help.rs
+++ b/tests/integration/commands/help.rs
@@ -1,7 +1,7 @@
 use insta::assert_snapshot;
+use rstest::rstest;
 
 use crate::common::{cli, exec_cmd};
-use rstest::rstest;
 
 #[rstest]
 #[case(vec![], "no_args")]

--- a/tests/integration/conformance.rs
+++ b/tests/integration/conformance.rs
@@ -1,8 +1,8 @@
-use crate::common::cli;
-use crate::common::exec_cmd;
+use std::{ffi::OsStr, fs};
+
 use insta::assert_snapshot;
-use std::ffi::OsStr;
-use std::fs;
+
+use crate::common::{cli, exec_cmd};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum JsonResult {

--- a/tests/integration/format_ast.rs
+++ b/tests/integration/format_ast.rs
@@ -1,7 +1,7 @@
-use crate::common::format_template;
-use crate::test_json::*;
 use insta::assert_snapshot;
 use jjpwrgem_parse::{ast::parse_str, format::uglify_value};
+
+use crate::{common::format_template, test_json::*};
 
 #[rstest_reuse::apply(format_template)]
 fn uglify(#[case] (name, input): (&str, &str)) {

--- a/xtask/src/npm.rs
+++ b/xtask/src/npm.rs
@@ -1,10 +1,11 @@
 mod metadata;
 
+use std::{collections::HashMap, fs};
+
 use anyhow::{Context, Ok, Result};
 use itertools::Itertools as _;
 use jjpwrgem_parse::format::LineEnding;
 use package_json::PackageJson;
-use std::{collections::HashMap, fs};
 
 use crate::npm::metadata::{
     PackageMetadata, PlatformConfig, build_platforms_from_targets,

--- a/xtask/src/plot.rs
+++ b/xtask/src/plot.rs
@@ -1,13 +1,17 @@
-use std::cmp::Ordering;
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::{
+    cmp::Ordering,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 use anyhow::{Context, Error, Result, anyhow, bail};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use jjpwrgem_parse::ast::{self, Value};
-use plotters::coord::Shift;
-use plotters::prelude::*;
-use plotters::style::{FontStyle, register_font};
+use plotters::{
+    coord::Shift,
+    prelude::*,
+    style::{FontStyle, register_font},
+};
 
 const CHART_WIDTH: u32 = 1280;
 const CHART_HEIGHT: u32 = 720;

--- a/xtask/src/template.rs
+++ b/xtask/src/template.rs
@@ -1,6 +1,6 @@
-use std::io::Write as _;
 use std::{
     fs,
+    io::Write as _,
     process::{Command, Stdio},
 };
 


### PR DESCRIPTION
add rustfmt.toml with `format_code_in_doc_comments`, `group_imports = "StdExternalCrate"`,
and `imports_granularity = "Crate"`. switch `just format`/`format-check` to `cargo +nightly fmt`
and set the CI format job to run on nightly. apply the resulting formatting across the workspace.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
