### PR TITLE
chore(docs): use cargo-rdme to process bytes2chars docs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,6 +50,10 @@ jobs:
         uses: taiki-e/install-action@just
       - name: Install cargo-shear
         uses: taiki-e/install-action@cargo-shear
+      - name: Install cargo-rdme
+        uses: taiki-e/install-action@v2.69.6
+        with:
+          tool: cargo-rdme@1.5
       - name: Configure Dependency Caching
         uses: Swatinem/rust-cache@v2
 

--- a/crates/bytes2chars/README.md
+++ b/crates/bytes2chars/README.md
@@ -1,13 +1,17 @@
+<!-- cargo-rdme start -->
+
 # bytes2chars
 
-lazily decodes utf-8 [`char`]s from bytes
+lazily decodes utf-8 [`char`][char]s from bytes
 
-provides lazy, fallible analogs to [`str::Chars`] ([`Utf8Chars`]) and [`str::CharIndices`] ([`Utf8CharIndices`]), as well as a lower-level push-based [`Utf8Decoder`]
+provides lazy, fallible analogs to [`str::Chars`][str-chars] ([`Utf8Chars`][utf8-chars]) and [`str::CharIndices`][str-char-indices] ([`Utf8CharIndices`][utf8-char-indices]), as well as a lower-level push-based [`Utf8Decoder`][utf8-decoder]
 
-[`str::Chars`]: core::str::Chars
-[`str::CharIndices`]: core::str::CharIndices
-[`Utf8Chars`]: crate::Utf8Chars
-[`Utf8CharIndices`]: crate::Utf8CharIndices
+[char]: https://doc.rust-lang.org/stable/std/primitive.char.html
+[str-chars]: https://doc.rust-lang.org/stable/std/str/struct.Chars.html
+[str-char-indices]: https://doc.rust-lang.org/stable/std/str/struct.CharIndices.html
+[utf8-chars]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8Chars.html
+[utf8-char-indices]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8CharIndices.html
+[utf8-decoder]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8Decoder.html
 
 ## design goals
 
@@ -18,17 +22,15 @@ provides lazy, fallible analogs to [`str::Chars`] ([`Utf8Chars`]) and [`str::Cha
 
 ## quick start
 
-prefer iterators like [`Utf8CharIndices`] or [`Utf8Chars`] if you have access to a byte iterator. [`Utf8Chars`] still tracks bytes for error context, so it's purely a convenience wrapper
+prefer iterators like [`Utf8CharIndices`][utf8-char-indices] or [`Utf8Chars`][utf8-chars] if you have access to a byte iterator. [`Utf8Chars`][utf8-chars] still tracks bytes for error context, so it's purely a convenience wrapper
 
-if you receive bytes in chunks, use the push-based [`Utf8Decoder`]
+if you receive bytes in chunks, use the push-based [`Utf8Decoder`][utf8-decoder]
 
 ## examples
 
 ### iterator api
 
 ```rust
-# use bytes2chars::{Result, Utf8CharIndices, Utf8Chars};
-# fn main() -> Result<()> {
 let input = b"\xF0\x9F\xA6\x80 rust".iter().copied();
 
 // decode into an iterator of chars and their positions
@@ -39,41 +41,38 @@ assert_eq!(indexed, expected);
 // convenience wrapper to decode into an iterator of chars
 let chars = Utf8Chars::from(input).collect::<Result<String>>()?;
 assert_eq!(chars, "🦀 rust");
-# Ok(())
-# }
 ```
 
 ### error handling
 
 ```rust
-# use bytes2chars::{Error, ErrorKind, Result, Utf8Chars};
-# fn main() -> Result<()> {
 let err = Utf8Chars::from(b"hello \x80 world".iter().copied())
     .collect::<Result<String>>()
     .unwrap_err();
 
-assert_eq!(err, Error { range: 6..7, kind: ErrorKind::InvalidLead(0x80) });
 assert_eq!(
-  err.to_string(),
-  "invalid utf-8 at bytes 6..7: byte 0x80 cannot start a UTF-8 sequence"
+    err,
+    Error {
+        range: 6..7,
+        kind: ErrorKind::InvalidLead(0x80)
+    }
 );
-# Ok(())
-# }
+assert_eq!(
+    err.to_string(),
+    "invalid utf-8 at bytes 6..7: byte 0x80 cannot start a UTF-8 sequence"
+);
 ```
 
 ### push based decoder
 
 ```rust
-# use bytes2chars::Utf8Decoder;
-# fn main() -> bytes2chars::Result<()> {
 let mut decoder = Utf8Decoder::new(0);
 assert_eq!(decoder.push(0xF0), None); // accumulating
 assert_eq!(decoder.push(0x9F), None);
 assert_eq!(decoder.push(0xA6), None);
 assert_eq!(decoder.push(0x80), Some(Ok((0, '🦀')))); // complete
 decoder.finish()?; // check for truncated sequence
-# Ok(())
-# }
+
 ```
 
 ## alternatives
@@ -85,3 +84,5 @@ eager and error context provides a range but not a particular cause
 ### [`utf8-decode`](https://docs.rs/utf8-decode/latest/utf8_decode/index.html)
 
 also lazy. error provides a range but not a particular cause. does not provide a push based decoder
+
+<!-- cargo-rdme end -->

--- a/crates/bytes2chars/src/lib.rs
+++ b/crates/bytes2chars/src/lib.rs
@@ -1,5 +1,100 @@
 #![no_std]
-#![doc = include_str!("../README.md")]
+//! # bytes2chars
+//!
+//! lazily decodes utf-8 [`char`][char]s from bytes
+//!
+//! provides lazy, fallible analogs to [`str::Chars`][str-chars] ([`Utf8Chars`][utf8-chars]) and [`str::CharIndices`][str-char-indices] ([`Utf8CharIndices`][utf8-char-indices]), as well as a lower-level push-based [`Utf8Decoder`][utf8-decoder]
+//!
+//! [char]: https://doc.rust-lang.org/stable/std/primitive.char.html
+//! [str-chars]: https://doc.rust-lang.org/stable/std/str/struct.Chars.html
+//! [str-char-indices]: https://doc.rust-lang.org/stable/std/str/struct.CharIndices.html
+//! [utf8-chars]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8Chars.html
+//! [utf8-char-indices]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8CharIndices.html
+//! [utf8-decoder]: https://docs.rs/bytes2chars/latest/bytes2chars/struct.Utf8Decoder.html
+//!
+//! ## design goals
+//!
+//! - rich errors—what went wrong and where
+//! - lazy
+//! - `no-std`
+//! - performance
+//!
+//! ## quick start
+//!
+//! prefer iterators like [`Utf8CharIndices`][utf8-char-indices] or [`Utf8Chars`][utf8-chars] if you have access to a byte iterator. [`Utf8Chars`][utf8-chars] still tracks bytes for error context, so it's purely a convenience wrapper
+//!
+//! if you receive bytes in chunks, use the push-based [`Utf8Decoder`][utf8-decoder]
+//!
+//! ## examples
+//!
+//! ### iterator api
+//!
+//! ```rust
+//! # use bytes2chars::{Result, Utf8CharIndices, Utf8Chars};
+//! # fn main() -> Result<()> {
+//! let input = b"\xF0\x9F\xA6\x80 rust".iter().copied();
+//!
+//! // decode into an iterator of chars and their positions
+//! let indexed = Utf8CharIndices::from(input.clone()).collect::<Result<Vec<_>>>()?;
+//! let expected = vec![(0, '🦀'), (4, ' '), (5, 'r'), (6, 'u'), (7, 's'), (8, 't')];
+//! assert_eq!(indexed, expected);
+//!
+//! // convenience wrapper to decode into an iterator of chars
+//! let chars = Utf8Chars::from(input).collect::<Result<String>>()?;
+//! assert_eq!(chars, "🦀 rust");
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### error handling
+//!
+//! ```rust
+//! # use bytes2chars::{Error, ErrorKind, Result, Utf8Chars};
+//! # fn main() -> Result<()> {
+//! let err = Utf8Chars::from(b"hello \x80 world".iter().copied())
+//!     .collect::<Result<String>>()
+//!     .unwrap_err();
+//!
+//! assert_eq!(
+//!     err,
+//!     Error {
+//!         range: 6..7,
+//!         kind: ErrorKind::InvalidLead(0x80)
+//!     }
+//! );
+//! assert_eq!(
+//!     err.to_string(),
+//!     "invalid utf-8 at bytes 6..7: byte 0x80 cannot start a UTF-8 sequence"
+//! );
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### push based decoder
+//!
+//! ```rust
+//! # use bytes2chars::Utf8Decoder;
+//! # fn main() -> bytes2chars::Result<()> {
+//! let mut decoder = Utf8Decoder::new(0);
+//! assert_eq!(decoder.push(0xF0), None); // accumulating
+//! assert_eq!(decoder.push(0x9F), None);
+//! assert_eq!(decoder.push(0xA6), None);
+//! assert_eq!(decoder.push(0x80), Some(Ok((0, '🦀')))); // complete
+//! decoder.finish()?; // check for truncated sequence
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## alternatives
+//!
+//! ### [`std::str::from_utf8`](https://doc.rust-lang.org/std/str/fn.from_utf8.html)
+//!
+//! eager and error context provides a range but not a particular cause
+//!
+//! ### [`utf8-decode`](https://docs.rs/utf8-decode/latest/utf8_decode/index.html)
+//!
+//! also lazy. error provides a range but not a particular cause. does not provide a push based decoder
 
 mod decoder;
 mod iter;

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ dev-install:
     cargo binstall cargo-diet -y
     cargo binstall cargo-dist -y
     cargo binstall release-plz -y
+    cargo binstall cargo-rdme@1.5 -y
 
 prettier_glob := "./**/*.{md,yaml,yml,ts,js}"
 
@@ -47,14 +48,27 @@ test-snapshot:
     cargo insta review
 
 xtask-command := "cargo run -p xtask -q --"
+rdme-command := "cargo rdme --workspace-project bytes2chars"
+prettier-bytes2chars := "npx -y prettier crates/bytes2chars/README.md"
+
+bytes2chars-readme:
+    cargo +nightly fmt -p bytes2chars
+    {{ rdme-command }} --force
+    {{ prettier-bytes2chars }} --write
+
+bytes2chars-readme-check:
+    {{ rdme-command }} --check
+    {{ prettier-bytes2chars }} --check
 
 # generate markdown files from templates
 readmes:
     {{ xtask-command }} generate-readmes
+    just bytes2chars-readme
 
 # verify markdown files match generated templates
 readmes-check:
     {{ xtask-command }} verify-readmes
+    just bytes2chars-readme-check
 
 npm-markdown:
     cp -f readme.md npm-template/README.md

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,6 +31,7 @@ pre-commit:
       glob:
         - "**/*.md"
         - "xtask/templates/**"
+        - "crates/bytes2chars/src/**"
       stage_fixed: true
     - run: just package-json
       glob:


### PR DESCRIPTION
crates.io does not handle intradoc links or test processing properly