### PR TITLE
deprecate serde json compat

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,7 @@
     "tests/conformance/JSONTestSuite": true
   },
   "coverage-gutters.coverageBaseDir": "./target/llvm-cov",
-  "rust-analyzer.cargo.features": ["jjpwrgem-parse/serde"]
+  "rust-analyzer.cargo.features": [
+    "jjpwrgem-parse/serde",
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "displaydoc",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,6 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "serde",
- "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-jjpwrgem-parse = { path = "crates/parse", version = "0.3.0" }
+jjpwrgem-parse = { path = "crates/parse", version = "0.4.0" }
 jjpwrgem-ui = { path = "crates/ui", version = "0.2.0" }
 displaydoc = "0.2.5"
 thiserror = "2.0.17"

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -9,10 +9,6 @@ publish = false
 displaydoc = { workspace = true }
 itertools = "0.14.0"
 serde = { version = "1", optional = true, features = ["derive"] }
-serde_json = { version = "1", features = [
-  "arbitrary_precision",
-  "preserve_order",
-], optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
@@ -20,4 +16,4 @@ rstest = { workspace = true }
 rstest_reuse = { workspace = true }
 
 [features]
-serde = ["dep:serde", "dep:serde_json"]
+serde = ["dep:serde"]

--- a/crates/parse/src/format/serde.rs
+++ b/crates/parse/src/format/serde.rs
@@ -1,52 +1,12 @@
-use crate::{
-    ast::Value,
-    format::{self, FormatOptions, LineEnding},
-};
+use crate::format;
+
+mod error;
 mod uglify;
 
-impl From<serde_json::Value> for Value<'_> {
-    fn from(value: serde_json::Value) -> Self {
-        match value {
-            serde_json::Value::Null => Value::Null,
-            serde_json::Value::Bool(b) => Value::Boolean(b),
-            serde_json::Value::Number(number) => Value::Number(number.to_string().into()),
-            serde_json::Value::String(s) => {
-                let s_static: &'static str = Box::leak(s.into_boxed_str());
-                Value::String(s_static)
-            }
-            serde_json::Value::Array(values) => {
-                Value::Array(values.into_iter().map(Value::from).collect())
-            }
-            serde_json::Value::Object(map) => {
-                let entries = map
-                    .into_iter()
-                    .map(|(k, v)| (&*k.leak(), v.into()))
-                    .collect::<Vec<_>>()
-                    .into();
-                Value::Object(entries)
-            }
-        }
-    }
-}
-
-/// A wrapper of [`crate::format::uglify_value`] that takes a
-/// [`serde_json::Value`] instead of a [`crate::ast::Value`]
-///
-/// See [`uglify_value`] for a higher level API
-/// ## Examples
-/// ```
-/// # use jjpwrgem_parse::format::serde::uglify_value;
-/// let val = serde_json::json!({ "rust is a must": "🦀" });
-/// assert_eq!(uglify_value(val), r#"{"rust is a must":"🦀"}"#);
-/// ```
-pub fn uglify_value(val: serde_json::Value) -> String {
-    format::uglify_value(&val.into())
-}
+pub use error::{Error, Result};
 
 /// Serializes a [`serde::Serialize`] value using this crate's compact JSON
 /// formatter.
-///
-/// See [`self::uglify_value`] for the [`serde_json::Value`] variant.
 ///
 /// ```
 /// # use std::collections::HashMap;
@@ -58,113 +18,8 @@ pub fn uglify_value(val: serde_json::Value) -> String {
 ///     r#"{"rust is a must":"🦀"}"#
 /// );
 /// ```
-pub fn uglify_serializable(val: impl serde::Serialize) -> serde_json::Result<String> {
+pub fn uglify_serializable(val: impl serde::Serialize) -> Result<String> {
     let mut serializer = format::uglify::UglifyEmitVisitor::default();
     val.serialize(&mut serializer)?;
     Ok(serializer.buf)
-}
-
-/// A wrapper of [`crate::format::prettify_value`] that takes a
-/// [`serde_json::Value`] instead of a [`crate::ast::Value`]
-///
-/// See [`prettify_value`] for a higher level API
-/// ## Examples
-/// ```
-/// # use jjpwrgem_parse::format::LineEnding;
-/// # use jjpwrgem_parse::format::serde::prettify_value;
-/// let val = serde_json::json!({ "rust is a must": "🦀" });
-/// let expected = r#"{
-///   "rust is a must": "🦀"
-/// }"#;
-/// assert_eq!(prettify_value(val, 80, LineEnding::Lf), expected);
-/// ```
-pub fn prettify_value(
-    val: serde_json::Value,
-    preferred_width: usize,
-    line_ending: LineEnding,
-) -> String {
-    format::prettify_value(&val.into(), preferred_width, line_ending)
-}
-
-/// Formats a [`serde::Serialize`] value using this crate's pretty JSON
-/// formatter.
-///
-/// See [`self::prettify_value`] for the [`serde_json::Value`] variant.
-///
-/// ```
-/// # use std::collections::HashMap;
-/// # use jjpwrgem_parse::format::LineEnding;
-/// # use jjpwrgem_parse::format::serde::prettify_serializable;
-/// let map: HashMap<String, String> =
-///     HashMap::from([("rust is a must".to_string(), "🦀".to_string())]);
-/// let expected = r#"{
-///   "rust is a must": "🦀"
-/// }"#;
-/// assert_eq!(
-///     prettify_serializable(map, 80, LineEnding::Lf).unwrap(),
-///     expected
-/// );
-/// ```
-pub fn prettify_serializable(
-    val: impl serde::Serialize,
-    preferred_width: usize,
-    line_ending: LineEnding,
-) -> serde_json::Result<String> {
-    Ok(prettify_value(
-        serde_json::to_value(val)?,
-        preferred_width,
-        line_ending,
-    ))
-}
-
-/// Formats a [`serde::Serialize`] value using this crate's configurable JSON
-/// formatter.
-///
-/// See [`self::format_value`] for the [`serde_json::Value`] variant.
-///
-/// ```
-/// # use std::collections::HashMap;
-/// # use jjpwrgem_parse::format::{FormatOptions, LineEnding};
-/// # use jjpwrgem_parse::format::serde::format_serializable;
-/// let map: HashMap<String, String> =
-///     HashMap::from([("rust is a must".to_string(), "🦀".to_string())]);
-/// let out = format_serializable(map, FormatOptions::prettify(LineEnding::Lf), 80).unwrap();
-/// let expected = r#"{
-///   "rust is a must": "🦀"
-/// }"#;
-/// assert_eq!(out, expected);
-/// ```
-pub fn format_serializable(
-    val: impl serde::Serialize,
-    options: FormatOptions,
-    preferred_width: usize,
-) -> serde_json::Result<String> {
-    Ok(format_value(
-        serde_json::to_value(val)?,
-        options,
-        preferred_width,
-    ))
-}
-
-/// A wrapper of [`format::format_value`] that takes a
-/// [`serde_json::Value`] instead of a [`crate::ast::Value`]
-///
-/// See [`format_value`] for a higher level API
-/// ## Examples
-/// ```
-/// # use jjpwrgem_parse::format::{FormatOptions, LineEnding};
-/// # use jjpwrgem_parse::format::serde::format_value;
-/// let val = serde_json::json!({ "rust is a must": "🦀" });
-/// let out = format_value(val, FormatOptions::prettify(LineEnding::Lf), 80);
-/// let expected = r#"{
-///   "rust is a must": "🦀"
-/// }"#;
-/// assert_eq!(out, expected);
-/// ```
-pub fn format_value(
-    val: serde_json::Value,
-    options: FormatOptions,
-    preferred_width: usize,
-) -> String {
-    format::format_value(&val.into(), &options, preferred_width)
 }

--- a/crates/parse/src/format/serde/error.rs
+++ b/crates/parse/src/format/serde/error.rs
@@ -1,0 +1,27 @@
+use std::fmt::{Display, Formatter};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error {
+    message: String,
+}
+
+impl std::error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
+        Self {
+            message: msg.to_string(),
+        }
+    }
+}

--- a/crates/parse/src/format/serde/uglify.rs
+++ b/crates/parse/src/format/serde/uglify.rs
@@ -5,6 +5,7 @@ use serde::ser::{
     SerializeTupleStruct, SerializeTupleVariant,
 };
 
+use super::error::Error;
 use crate::{
     format::{Emitter, uglify::UglifyEmitVisitor},
     tokens::{NULL, lexical::JsonChar},
@@ -39,7 +40,7 @@ fn emit_json_string(emitter: &mut impl Emitter, s: &str) {
 }
 
 impl UglifyEmitVisitor {
-    fn serialize_number<N: Display>(&mut self, number: N) -> serde_json::Result<()> {
+    fn serialize_number<N: Display>(&mut self, number: N) -> Result<(), Error> {
         write!(&mut self.buf, "{number}").expect("write to string");
         Ok(())
     }
@@ -52,15 +53,15 @@ fn emit_item_prefix(first: &mut bool, emitter: &mut impl Emitter) {
     *first = false;
 }
 
-fn map_key_bytes_error() -> serde_json::Error {
+fn map_key_bytes_error() -> Error {
     ser::Error::custom("JSON object keys cannot be byte arrays")
 }
 
-fn map_key_enum_error() -> serde_json::Error {
+fn map_key_enum_error() -> Error {
     ser::Error::custom("JSON object keys cannot be enum objects")
 }
 
-fn map_key_scalar_error() -> serde_json::Error {
+fn map_key_scalar_error() -> Error {
     ser::Error::custom("JSON object keys must be scalars")
 }
 
@@ -78,7 +79,7 @@ macro_rules! impl_seq_like {
     ($trait_name:ident, $method_name:ident) => {
         impl $trait_name for SeqSerializer<'_> {
             type Ok = ();
-            type Error = serde_json::Error;
+            type Error = Error;
 
             fn $method_name<T>(&mut self, value: &T) -> Result<(), Self::Error>
             where
@@ -116,7 +117,7 @@ macro_rules! impossible_map_key_methods {
 
 impl<'a> ser::Serializer for &'a mut UglifyEmitVisitor {
     type Ok = ();
-    type Error = serde_json::Error;
+    type Error = Error;
     type SerializeSeq = SeqSerializer<'a>;
     type SerializeTuple = SeqSerializer<'a>;
     type SerializeTupleStruct = SeqSerializer<'a>;
@@ -319,7 +320,7 @@ pub struct SeqSerializer<'a> {
 }
 
 impl SeqSerializer<'_> {
-    fn serialize_item<T>(&mut self, value: &T) -> serde_json::Result<()>
+    fn serialize_item<T>(&mut self, value: &T) -> Result<(), Error>
     where
         T: ?Sized + serde::Serialize,
     {
@@ -327,7 +328,7 @@ impl SeqSerializer<'_> {
         value.serialize(&mut *self.serializer)
     }
 
-    fn end_array(self) -> serde_json::Result<()> {
+    fn end_array(self) -> Result<(), Error> {
         self.serializer.emit_array_close();
         Ok(())
     }
@@ -344,7 +345,7 @@ pub struct TupleVariantSerializer<'a> {
 
 impl SerializeTupleVariant for TupleVariantSerializer<'_> {
     type Ok = ();
-    type Error = serde_json::Error;
+    type Error = Error;
 
     fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
@@ -373,7 +374,7 @@ impl MapSerializer<'_> {
         self.serializer.emit_key_val_delim();
     }
 
-    fn end_object(self) -> serde_json::Result<()> {
+    fn end_object(self) -> Result<(), Error> {
         self.serializer.emit_object_close();
         Ok(())
     }
@@ -381,7 +382,7 @@ impl MapSerializer<'_> {
 
 impl SerializeMap for MapSerializer<'_> {
     type Ok = ();
-    type Error = serde_json::Error;
+    type Error = Error;
 
     fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
@@ -406,7 +407,7 @@ impl SerializeMap for MapSerializer<'_> {
 
 impl SerializeStruct for MapSerializer<'_> {
     type Ok = ();
-    type Error = serde_json::Error;
+    type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
@@ -428,7 +429,7 @@ pub struct StructVariantSerializer<'a> {
 
 impl SerializeStructVariant for StructVariantSerializer<'_> {
     type Ok = ();
-    type Error = serde_json::Error;
+    type Error = Error;
 
     fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
     where
@@ -451,14 +452,14 @@ struct MapKeySerializer;
 
 impl ser::Serializer for MapKeySerializer {
     type Ok = String;
-    type Error = serde_json::Error;
-    type SerializeSeq = ser::Impossible<String, serde_json::Error>;
-    type SerializeTuple = ser::Impossible<String, serde_json::Error>;
-    type SerializeTupleStruct = ser::Impossible<String, serde_json::Error>;
-    type SerializeTupleVariant = ser::Impossible<String, serde_json::Error>;
-    type SerializeMap = ser::Impossible<String, serde_json::Error>;
-    type SerializeStruct = ser::Impossible<String, serde_json::Error>;
-    type SerializeStructVariant = ser::Impossible<String, serde_json::Error>;
+    type Error = Error;
+    type SerializeSeq = ser::Impossible<String, Error>;
+    type SerializeTuple = ser::Impossible<String, Error>;
+    type SerializeTupleStruct = ser::Impossible<String, Error>;
+    type SerializeTupleVariant = ser::Impossible<String, Error>;
+    type SerializeMap = ser::Impossible<String, Error>;
+    type SerializeStruct = ser::Impossible<String, Error>;
+    type SerializeStructVariant = ser::Impossible<String, Error>;
 
     map_key_scalar_to_string!(
         serialize_bool: bool,

--- a/xtask/src/npm.rs
+++ b/xtask/src/npm.rs
@@ -2,7 +2,7 @@ mod metadata;
 
 use std::{collections::HashMap, fs};
 
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Ok, Result, anyhow};
 use itertools::Itertools as _;
 use jjpwrgem_parse::format::LineEnding;
 use package_json::PackageJson;
@@ -78,11 +78,13 @@ impl Default for NpmPackageConfig {
 }
 
 pub fn write_package_json() -> Result<()> {
-    let formatted_json = jjpwrgem_parse::format::serde::prettify_serializable(
-        &package_json_from_env()?,
-        80,
-        LineEnding::Lf,
-    )?;
+    // it's a bit silly to reparse like this, but it's for a dev only script, so
+    // I don't mind so much
+    let compact_json =
+        jjpwrgem_parse::format::serde::uglify_serializable(&package_json_from_env()?)?;
+    let ast =
+        jjpwrgem_parse::ast::parse_str(&compact_json).map_err(|err| anyhow!(err.to_string()))?;
+    let formatted_json = jjpwrgem_parse::format::prettify_value(&ast, 80, LineEnding::Lf);
 
     let static_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../npm-template/package.json");
     fs::write(static_path, formatted_json)?;


### PR DESCRIPTION
- removes serde json compat layer
- implements Serializable for the uglify flow


The serde feature was a bit half baked for some time now, and the `From<serde_json::Value` impl for `Value` leaked memory as a quick fix for dev tooling and scripts, but this is not obvious to a consumer

The `Value` is not intended to be as general purpose as serde_json anyways. There may be future changes to the underlying representation
