### PR TITLE
perf/peek whitespace

### DIFF
--- a/benches/json.md
+++ b/benches/json.md
@@ -22,42 +22,42 @@ The following JSON fixtures are used across benchmarks:
 
 |                           |  `jjpwrgem`  | `serde_json` | `simd_json`  |  `sonic_rs`  |
 | :------------------------ | :----------: | :----------: | :----------: | :----------: |
-| time (canada)             |   20.18 ms   |   12.64 ms   |   5.17 ms    |   2.89 ms    |
-| throughput (canada)       | 106.38 MiB/s | 169.85 MiB/s | 415.01 MiB/s | 743.51 MiB/s |
-| time (citm_catalog)       |   4.81 ms    |   3.22 ms    |   1.81 ms    |   1.06 ms    |
-| throughput (citm_catalog) | 342.62 MiB/s | 512.34 MiB/s | 909.85 MiB/s |  1.52 GiB/s  |
-| time (twitter)            |   2.24 ms    |   1.82 ms    |  863.12 µs   |  416.82 µs   |
-| throughput (twitter)      | 269.41 MiB/s | 331.09 MiB/s | 697.77 MiB/s |  1.41 GiB/s  |
+| time (canada)             |   21.39 ms   |   13.66 ms   |   9.31 ms    |   2.69 ms    |
+| throughput (canada)       | 100.36 MiB/s | 157.21 MiB/s | 230.51 MiB/s | 799.29 MiB/s |
+| time (citm_catalog)       |   5.20 ms    |   3.69 ms    |   1.95 ms    |   1.08 ms    |
+| throughput (citm_catalog) | 316.97 MiB/s | 446.12 MiB/s | 843.10 MiB/s |  1.50 GiB/s  |
+| time (twitter)            |   2.69 ms    |   2.02 ms    |  864.46 µs   |  413.18 µs   |
+| throughput (twitter)      | 224.08 MiB/s | 297.73 MiB/s | 696.68 MiB/s |  1.42 GiB/s  |
 
 ## prettify_ast
 
 |                           |  `sonic_rs`  | `serde_json` | `simd_json`  | `jjpwrgem` |
 | :------------------------ | :----------: | :----------: | :----------: | :--------: |
-| time (canada)             |   6.94 ms    |   6.03 ms    |   5.36 ms    |  1.67 ms   |
-| throughput (canada)       | 309.36 MiB/s | 355.90 MiB/s | 400.35 MiB/s | 1.26 GiB/s |
-| time (citm_catalog)       |   1.40 ms    |   1.19 ms    |  972.12 µs   | 933.11 µs  |
-| throughput (citm_catalog) |  1.15 GiB/s  |  1.35 GiB/s  |  1.65 GiB/s  | 1.72 GiB/s |
-| time (twitter)            |  472.09 µs   |  539.06 µs   |  473.95 µs   | 298.64 µs  |
-| throughput (twitter)      |  1.25 GiB/s  |  1.09 GiB/s  |  1.24 GiB/s  | 1.97 GiB/s |
+| time (canada)             |   7.04 ms    |   6.30 ms    |   5.53 ms    |  1.75 ms   |
+| throughput (canada)       | 305.07 MiB/s | 340.65 MiB/s | 387.95 MiB/s | 1.20 GiB/s |
+| time (citm_catalog)       |   1.48 ms    |   1.32 ms    |   1.02 ms    |  1.01 ms   |
+| throughput (citm_catalog) |  1.09 GiB/s  |  1.22 GiB/s  |  1.58 GiB/s  | 1.59 GiB/s |
+| time (twitter)            |  505.86 µs   |  612.46 µs   |  492.70 µs   | 320.85 µs  |
+| throughput (twitter)      |  1.16 GiB/s  | 983.35 MiB/s |  1.19 GiB/s  | 1.83 GiB/s |
 
 ## uglify_ast
 
 |                           |  `sonic_rs`  | `simd_json`  | `serde_json` | `jjpwrgem` |
 | :------------------------ | :----------: | :----------: | :----------: | :--------: |
-| time (canada)             |   3.58 ms    |   3.26 ms    |   2.87 ms    | 734.19 µs  |
-| throughput (canada)       | 598.85 MiB/s | 659.30 MiB/s | 747.90 MiB/s | 2.86 GiB/s |
-| time (citm_catalog)       |  583.26 µs   |  439.36 µs   |  520.63 µs   | 262.31 µs  |
-| throughput (citm_catalog) |  2.76 GiB/s  |  3.66 GiB/s  |  3.09 GiB/s  | 6.13 GiB/s |
-| time (twitter)            |  274.44 µs   |  352.39 µs   |  369.98 µs   | 124.35 µs  |
-| throughput (twitter)      |  2.14 GiB/s  |  1.67 GiB/s  |  1.59 GiB/s  | 4.73 GiB/s |
+| time (canada)             |   3.86 ms    |   3.28 ms    |   2.99 ms    | 778.93 µs  |
+| throughput (canada)       | 555.72 MiB/s | 653.98 MiB/s | 718.31 MiB/s | 2.69 GiB/s |
+| time (citm_catalog)       |  616.20 µs   |  503.55 µs   |  515.18 µs   | 280.56 µs  |
+| throughput (citm_catalog) |  2.61 GiB/s  |  3.19 GiB/s  |  3.12 GiB/s  | 5.73 GiB/s |
+| time (twitter)            |  284.97 µs   |  394.73 µs   |  381.14 µs   | 133.70 µs  |
+| throughput (twitter)      |  2.06 GiB/s  |  1.49 GiB/s  |  1.54 GiB/s  | 4.40 GiB/s |
 
 ## uglify_tokens
 
 |                           |  `jjpwrgem`  |
 | :------------------------ | :----------: |
-| time (canada)             |   11.07 ms   |
-| throughput (canada)       | 193.94 MiB/s |
-| time (citm_catalog)       |   4.14 ms    |
-| throughput (citm_catalog) | 397.89 MiB/s |
-| time (twitter)            |   1.96 ms    |
-| throughput (twitter)      | 307.12 MiB/s |
+| time (canada)             |   12.17 ms   |
+| throughput (canada)       | 176.36 MiB/s |
+| time (citm_catalog)       |   4.44 ms    |
+| throughput (citm_catalog) | 371.13 MiB/s |
+| time (twitter)            |   2.38 ms    |
+| throughput (twitter)      | 253.27 MiB/s |

--- a/benches/output/json_deser.md
+++ b/benches/output/json_deser.md
@@ -2,9 +2,9 @@
 
 |                           |  `jjpwrgem`  | `serde_json` | `simd_json`  |  `sonic_rs`  |
 | :------------------------ | :----------: | :----------: | :----------: | :----------: |
-| time (canada)             |   20.18 ms   |   12.64 ms   |   5.17 ms    |   2.89 ms    |
-| throughput (canada)       | 106.38 MiB/s | 169.85 MiB/s | 415.01 MiB/s | 743.51 MiB/s |
-| time (citm_catalog)       |   4.81 ms    |   3.22 ms    |   1.81 ms    |   1.06 ms    |
-| throughput (citm_catalog) | 342.62 MiB/s | 512.34 MiB/s | 909.85 MiB/s |  1.52 GiB/s  |
-| time (twitter)            |   2.24 ms    |   1.82 ms    |  863.12 µs   |  416.82 µs   |
-| throughput (twitter)      | 269.41 MiB/s | 331.09 MiB/s | 697.77 MiB/s |  1.41 GiB/s  |
+| time (canada)             |   21.39 ms   |   13.66 ms   |   9.31 ms    |   2.69 ms    |
+| throughput (canada)       | 100.36 MiB/s | 157.21 MiB/s | 230.51 MiB/s | 799.29 MiB/s |
+| time (citm_catalog)       |   5.20 ms    |   3.69 ms    |   1.95 ms    |   1.08 ms    |
+| throughput (citm_catalog) | 316.97 MiB/s | 446.12 MiB/s | 843.10 MiB/s |  1.50 GiB/s  |
+| time (twitter)            |   2.69 ms    |   2.02 ms    |  864.46 µs   |  413.18 µs   |
+| throughput (twitter)      | 224.08 MiB/s | 297.73 MiB/s | 696.68 MiB/s |  1.42 GiB/s  |

--- a/benches/output/json_prettify.md
+++ b/benches/output/json_prettify.md
@@ -2,9 +2,9 @@
 
 |                           |  `sonic_rs`  | `serde_json` | `simd_json`  | `jjpwrgem` |
 | :------------------------ | :----------: | :----------: | :----------: | :--------: |
-| time (canada)             |   6.94 ms    |   6.03 ms    |   5.36 ms    |  1.67 ms   |
-| throughput (canada)       | 309.36 MiB/s | 355.90 MiB/s | 400.35 MiB/s | 1.26 GiB/s |
-| time (citm_catalog)       |   1.40 ms    |   1.19 ms    |  972.12 µs   | 933.11 µs  |
-| throughput (citm_catalog) |  1.15 GiB/s  |  1.35 GiB/s  |  1.65 GiB/s  | 1.72 GiB/s |
-| time (twitter)            |  472.09 µs   |  539.06 µs   |  473.95 µs   | 298.64 µs  |
-| throughput (twitter)      |  1.25 GiB/s  |  1.09 GiB/s  |  1.24 GiB/s  | 1.97 GiB/s |
+| time (canada)             |   7.04 ms    |   6.30 ms    |   5.53 ms    |  1.75 ms   |
+| throughput (canada)       | 305.07 MiB/s | 340.65 MiB/s | 387.95 MiB/s | 1.20 GiB/s |
+| time (citm_catalog)       |   1.48 ms    |   1.32 ms    |   1.02 ms    |  1.01 ms   |
+| throughput (citm_catalog) |  1.09 GiB/s  |  1.22 GiB/s  |  1.58 GiB/s  | 1.59 GiB/s |
+| time (twitter)            |  505.86 µs   |  612.46 µs   |  492.70 µs   | 320.85 µs  |
+| throughput (twitter)      |  1.16 GiB/s  | 983.35 MiB/s |  1.19 GiB/s  | 1.83 GiB/s |

--- a/benches/output/json_uglify.md
+++ b/benches/output/json_uglify.md
@@ -2,20 +2,20 @@
 
 |                           |  `sonic_rs`  | `simd_json`  | `serde_json` | `jjpwrgem` |
 | :------------------------ | :----------: | :----------: | :----------: | :--------: |
-| time (canada)             |   3.58 ms    |   3.26 ms    |   2.87 ms    | 734.19 µs  |
-| throughput (canada)       | 598.85 MiB/s | 659.30 MiB/s | 747.90 MiB/s | 2.86 GiB/s |
-| time (citm_catalog)       |  583.26 µs   |  439.36 µs   |  520.63 µs   | 262.31 µs  |
-| throughput (citm_catalog) |  2.76 GiB/s  |  3.66 GiB/s  |  3.09 GiB/s  | 6.13 GiB/s |
-| time (twitter)            |  274.44 µs   |  352.39 µs   |  369.98 µs   | 124.35 µs  |
-| throughput (twitter)      |  2.14 GiB/s  |  1.67 GiB/s  |  1.59 GiB/s  | 4.73 GiB/s |
+| time (canada)             |   3.86 ms    |   3.28 ms    |   2.99 ms    | 778.93 µs  |
+| throughput (canada)       | 555.72 MiB/s | 653.98 MiB/s | 718.31 MiB/s | 2.69 GiB/s |
+| time (citm_catalog)       |  616.20 µs   |  503.55 µs   |  515.18 µs   | 280.56 µs  |
+| throughput (citm_catalog) |  2.61 GiB/s  |  3.19 GiB/s  |  3.12 GiB/s  | 5.73 GiB/s |
+| time (twitter)            |  284.97 µs   |  394.73 µs   |  381.14 µs   | 133.70 µs  |
+| throughput (twitter)      |  2.06 GiB/s  |  1.49 GiB/s  |  1.54 GiB/s  | 4.40 GiB/s |
 
 ## uglify_tokens
 
 |                           |  `jjpwrgem`  |
 | :------------------------ | :----------: |
-| time (canada)             |   11.07 ms   |
-| throughput (canada)       | 193.94 MiB/s |
-| time (citm_catalog)       |   4.14 ms    |
-| throughput (citm_catalog) | 397.89 MiB/s |
-| time (twitter)            |   1.96 ms    |
-| throughput (twitter)      | 307.12 MiB/s |
+| time (canada)             |   12.17 ms   |
+| throughput (canada)       | 176.36 MiB/s |
+| time (citm_catalog)       |   4.44 ms    |
+| throughput (citm_catalog) | 371.13 MiB/s |
+| time (twitter)            |   2.38 ms    |
+| throughput (twitter)      | 253.27 MiB/s |

--- a/crates/parse/src/tokens/stream.rs
+++ b/crates/parse/src/tokens/stream.rs
@@ -8,15 +8,24 @@ use crate::{
     },
 };
 
+fn skip_whitespace(bytes: &[u8]) -> usize {
+    bytes
+        .iter()
+        .position(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
+        .unwrap_or(bytes.len())
+}
+
 #[derive(Debug, Clone)]
 struct CharsWithContext<'a> {
     iter: CharIndices<'a>,
+    offset: usize,
 }
 
 impl<'a> CharsWithContext<'a> {
-    fn new(s: &'a str) -> Self {
+    fn new(s: &'a str, offset: usize) -> Self {
         Self {
             iter: s.char_indices(),
+            offset,
         }
     }
 }
@@ -25,7 +34,7 @@ impl<'a> Iterator for CharsWithContext<'a> {
     type Item = CharWithContext;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(Into::into)
+        self.iter.next().map(|(i, c)| (i + self.offset, c).into())
     }
 }
 
@@ -38,17 +47,21 @@ struct TokenStreamInner<'a> {
 impl<'a> TokenStreamInner<'a> {
     fn new(s: &'a str) -> Self {
         Self {
-            chars: CharsWithContext::new(s).peekable(),
+            chars: CharsWithContext::new(s, 0).peekable(),
             input: s,
         }
     }
 
     fn consume_whitespace(&mut self) {
-        while self
-            .chars
-            .next_if(|CharWithContext(_, x)| x.is_whitespace())
-            .is_some()
-        {}
+        let Some(CharWithContext(r, c)) = self.chars.peek() else {
+            return;
+        };
+        if !c.is_whitespace() {
+            return;
+        }
+
+        let new_pos = r.start + skip_whitespace(&self.input.as_bytes()[r.start..]);
+        self.chars = CharsWithContext::new(&self.input[new_pos..], new_pos).peekable();
     }
 }
 

--- a/crates/parse/src/tokens/stream.rs
+++ b/crates/parse/src/tokens/stream.rs
@@ -11,6 +11,7 @@ use crate::{
 fn skip_whitespace(bytes: &[u8]) -> usize {
     bytes
         .iter()
+        // TODO: create and use ByteWithContext
         .position(|&b| !matches!(b, b' ' | b'\t' | b'\n' | b'\r'))
         .unwrap_or(bytes.len())
 }


### PR DESCRIPTION
- **perf(parse): replace next_if whitespace loop with peek fast path + byte scan**
- **chore: add bench output**

| dataset | improvement |
|---|---|
| canada | +6–8% throughput |
| citm_catalog | +7–10% |
| twitter | +10–14% |

Note that the generated files will of course change based on hardware and noisiness

