### PR TITLE
refactor!: store parse AST as source ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes2chars",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.dependencies]
-jjpwrgem-parse = { path = "crates/parse", version = "0.10.0" }
+jjpwrgem-parse = { path = "crates/parse", version = "0.11.0" }
 jjpwrgem-ui = { path = "crates/ui", version = "0.2.0" }
 displaydoc = "0.2.5"
 thiserror = "2.0.17"

--- a/benches/benches/json_deser.rs
+++ b/benches/benches/json_deser.rs
@@ -4,7 +4,7 @@ use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, 
 
 mod json_common;
 
-use jjpwrgem_parse::ast::parse_str;
+use jjpwrgem_parse::ast::Document;
 use json_common::{include_impl, load_inputs};
 
 fn bench_deser(c: &mut Criterion) {
@@ -19,7 +19,7 @@ fn bench_deser(c: &mut Criterion) {
                 BenchmarkId::new("jjpwrgem", name),
                 json.as_str(),
                 |b, json| {
-                    b.iter(|| parse_str(black_box(json)).unwrap());
+                    b.iter(|| Document::parse(black_box(json)).unwrap());
                 },
             );
         }

--- a/benches/benches/json_iai.rs
+++ b/benches/benches/json_iai.rs
@@ -5,8 +5,8 @@ use gungraun::{
     library_benchmark_group, main,
 };
 use jjpwrgem_parse::{
-    ast::{Value, parse_str},
-    format::{LineEnding, prettify_value_into, uglify_str},
+    ast::Document,
+    format::{LineEnding, prettify_document_into, uglify_str},
     tokens::TokenStream,
 };
 
@@ -27,8 +27,8 @@ fn branch_sim_config() -> LibraryBenchmarkConfig {
 #[bench::citm(CITM)]
 #[bench::canada(CANADA)]
 #[bench::twitter(TWITTER)]
-fn bench_deser(json: &'static str) -> jjpwrgem_parse::ast::Value<'static> {
-    parse_str(black_box(json)).unwrap()
+fn bench_deser(json: &'static str) -> Document<&'static str> {
+    Document::parse(black_box(json)).unwrap()
 }
 
 #[library_benchmark]
@@ -39,25 +39,25 @@ fn bench_uglify_tokens(json: &'static str) -> String {
     uglify_str(black_box(json)).unwrap()
 }
 
-fn setup_citm_ast() -> Value<'static> {
-    parse_str(CITM).unwrap()
+fn setup_citm_ast() -> Document<&'static str> {
+    Document::parse(CITM).unwrap()
 }
 
-fn setup_canada_ast() -> Value<'static> {
-    parse_str(CANADA).unwrap()
+fn setup_canada_ast() -> Document<&'static str> {
+    Document::parse(CANADA).unwrap()
 }
 
-fn setup_twitter_ast() -> Value<'static> {
-    parse_str(TWITTER).unwrap()
+fn setup_twitter_ast() -> Document<&'static str> {
+    Document::parse(TWITTER).unwrap()
 }
 
 #[library_benchmark]
 #[bench::citm(setup = setup_citm_ast)]
 #[bench::canada(setup = setup_canada_ast)]
 #[bench::twitter(setup = setup_twitter_ast)]
-fn bench_prettify_ast(ast: Value<'static>) -> String {
+fn bench_prettify_ast(doc: Document<&'static str>) -> String {
     let mut buf = String::new();
-    prettify_value_into(&mut buf, black_box(&ast), 80, LineEnding::Lf);
+    prettify_document_into(&mut buf, black_box(&doc), 80, LineEnding::Lf);
     buf
 }
 

--- a/benches/benches/json_number_normalization.rs
+++ b/benches/benches/json_number_normalization.rs
@@ -2,8 +2,8 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use jjpwrgem_parse::{
-    ast::parse_str,
-    format::{LineEnding, prettify_value_into, uglify_value_into},
+    ast::Document,
+    format::{LineEnding, prettify_document_into, uglify_document_into},
 };
 
 const ZERO_EXPONENT_ARRAY: &str = r#"[
@@ -33,7 +33,7 @@ fn bench_deser(c: &mut Criterion) {
     for (name, json) in INPUTS {
         group.throughput(Throughput::Bytes(json.len() as u64));
         group.bench_function(BenchmarkId::new("jjpwrgem", name), |b| {
-            b.iter(|| parse_str(black_box(json)).unwrap());
+            b.iter(|| Document::parse(black_box(json)).unwrap());
         });
     }
 
@@ -46,15 +46,15 @@ fn bench_prettify(c: &mut Criterion) {
     for (name, json) in INPUTS {
         group.throughput(Throughput::Bytes(json.len() as u64));
 
-        let ast = parse_str(json).unwrap();
+        let ast = Document::parse(*json).unwrap();
         let mut probe = String::new();
-        prettify_value_into(&mut probe, &ast, 80, LineEnding::Lf);
+        prettify_document_into(&mut probe, &ast, 80, LineEnding::Lf);
         let mut buf = String::with_capacity(probe.len());
 
         group.bench_function(BenchmarkId::new("jjpwrgem", name), |b| {
             b.iter(|| {
                 buf.clear();
-                prettify_value_into(&mut buf, black_box(&ast), 80, LineEnding::Lf);
+                prettify_document_into(&mut buf, black_box(&ast), 80, LineEnding::Lf);
                 black_box(&buf);
             });
         });
@@ -69,15 +69,15 @@ fn bench_uglify(c: &mut Criterion) {
     for (name, json) in INPUTS {
         group.throughput(Throughput::Bytes(json.len() as u64));
 
-        let ast = parse_str(json).unwrap();
+        let ast = Document::parse(*json).unwrap();
         let mut probe = String::new();
-        uglify_value_into(&mut probe, &ast);
+        uglify_document_into(&mut probe, &ast);
         let mut buf = String::with_capacity(probe.len());
 
         group.bench_function(BenchmarkId::new("jjpwrgem", name), |b| {
             b.iter(|| {
                 buf.clear();
-                uglify_value_into(&mut buf, black_box(&ast));
+                uglify_document_into(&mut buf, black_box(&ast));
                 black_box(&buf);
             });
         });

--- a/benches/benches/json_prettify.rs
+++ b/benches/benches/json_prettify.rs
@@ -2,8 +2,8 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use jjpwrgem_parse::{
-    ast::parse_str,
-    format::{LineEnding, prettify_value_into},
+    ast::Document,
+    format::{LineEnding, prettify_document_into},
 };
 use simd_json::prelude::Writable as _;
 
@@ -19,15 +19,15 @@ fn bench_prettify_ast(c: &mut Criterion) {
         // Normalize throughput by source size so all formatters are comparable.
         group.throughput(Throughput::Bytes(json.len() as u64));
 
-        let ast = parse_str(json).unwrap();
+        let ast = Document::parse(json.as_str()).unwrap();
         if include_impl("jjpwrgem") {
             let mut probe = String::new();
-            prettify_value_into(&mut probe, &ast, 80, LineEnding::Lf);
+            prettify_document_into(&mut probe, &ast, 80, LineEnding::Lf);
             let mut jjp_buf = String::with_capacity(probe.len());
             group.bench_function(BenchmarkId::new("jjpwrgem", name), |b| {
                 b.iter(|| {
                     jjp_buf.clear();
-                    prettify_value_into(&mut jjp_buf, black_box(&ast), 80, LineEnding::Lf);
+                    prettify_document_into(&mut jjp_buf, black_box(&ast), 80, LineEnding::Lf);
                     black_box(&jjp_buf);
                 });
             });

--- a/benches/benches/json_uglify.rs
+++ b/benches/benches/json_uglify.rs
@@ -2,8 +2,8 @@ use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use jjpwrgem_parse::{
-    ast::parse_str,
-    format::{uglify_str, uglify_value_into},
+    ast::Document,
+    format::{uglify_document_into, uglify_str},
 };
 use simd_json::prelude::Writable as _;
 
@@ -18,15 +18,15 @@ fn bench_uglify_ast(c: &mut Criterion, inputs: &[(&str, String)]) {
         // Normalize throughput by source size so all formatters are comparable.
         group.throughput(Throughput::Bytes(json.len() as u64));
 
-        let ast = parse_str(json).unwrap();
+        let ast = Document::parse(json.as_str()).unwrap();
         if include_impl("jjpwrgem") {
             let mut probe = String::new();
-            uglify_value_into(&mut probe, &ast);
+            uglify_document_into(&mut probe, &ast);
             let mut jjp_buf = String::with_capacity(probe.len());
             group.bench_function(BenchmarkId::new("jjpwrgem", name), |b| {
                 b.iter(|| {
                     jjp_buf.clear();
-                    uglify_value_into(&mut jjp_buf, black_box(&ast));
+                    uglify_document_into(&mut jjp_buf, black_box(&ast));
                     black_box(&jjp_buf);
                 });
             });

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT"
 publish = false

--- a/crates/parse/src/ast.rs
+++ b/crates/parse/src/ast.rs
@@ -1,3 +1,5 @@
+use core::range::Range;
+
 use visitor::AstVisitor;
 
 use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
@@ -5,7 +7,7 @@ use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ObjectEntries(pub(crate) Vec<(Range<usize>, Value)>);
 
-impl<'a> ObjectEntries<'a> {
+impl ObjectEntries {
     pub fn new() -> Self {
         Self(Vec::new())
     }
@@ -27,63 +29,105 @@ impl<'a> ObjectEntries<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Value<'a> {
+pub enum Value {
     Null,
-    String(&'a str),
+    /// excludes surrounding quotes
+    String(Range<usize>),
     Number {
-        mantissa: &'a str,
-        exponent: Option<&'a str>,
+        mantissa: Range<usize>,
+        exponent: Option<Range<usize>>,
     },
-    Object(ObjectEntries<'a>),
-    Array(Vec<Value<'a>>),
+    Object(ObjectEntries),
+    Array(Vec<Value>),
     Boolean(bool),
 }
 
-impl Value<'_> {
-    pub fn to_f64(&self) -> Option<f64> {
+impl Value {
+    pub(crate) fn to_f64(&self, source: &str) -> Option<f64> {
         let Value::Number { mantissa, exponent } = self else {
             return None;
         };
+        let m = &source[*mantissa];
         if let Some(exponent) = exponent {
-            format!("{mantissa}e{exponent}").parse().ok()
+            let e = &source[*exponent];
+            format!("{m}e{e}").parse().ok()
         } else {
-            mantissa.parse().ok()
+            m.parse().ok()
         }
     }
 }
 
-pub fn parse_str<'a>(json: &'a str) -> Result<Value<'a>> {
-    let mut ast = AstVisitor::new();
-    parse_tokens(&mut TokenStream::new(json), json, true, &mut ast)?;
-    Ok(ast
-        .finish()
-        .expect("visitor should error if empty or unfinished"))
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Document<S> {
+    source: S,
+    root: Value,
+}
+
+impl<S: AsRef<str>> Document<S> {
+    pub fn parse(source: S) -> Result<Self> {
+        let mut ast = AstVisitor::new();
+        parse_tokens(
+            &mut TokenStream::new(source.as_ref()),
+            source.as_ref(),
+            true,
+            &mut ast,
+        )?;
+        let root = ast
+            .finish()
+            .expect("visitor should error if empty or unfinished");
+        Ok(Self { source, root })
+    }
+
+    pub fn root(&self) -> &Value {
+        &self.root
+    }
+
+    pub fn slice(&self, range: Range<usize>) -> &str {
+        &self.source.as_ref()[range]
+    }
+
+    pub fn get_object_value<'a>(&self, entries: &'a ObjectEntries, key: &str) -> Option<&'a Value> {
+        entries.find(self.source.as_ref(), key)
+    }
+
+    pub fn as_str<'a>(&'a self, value: &Value) -> Option<&'a str> {
+        match value {
+            Value::String(r) => Some(self.slice(*r)),
+            _ => None,
+        }
+    }
+
+    pub fn parse_f64(&self, value: &Value) -> Option<f64> {
+        value.to_f64(self.source.as_ref())
+    }
 }
 
 mod visitor {
+    use core::range::Range;
+
     use crate::{
         ast::{ObjectEntries, Value},
         traverse::Visitor,
     };
 
     #[derive(Debug, Default)]
-    pub struct AstVisitor<'a> {
-        stack: Vec<AstFrame<'a>>,
-        result: Option<Value<'a>>,
+    pub struct AstVisitor {
+        stack: Vec<AstFrame>,
+        result: Option<Value>,
     }
 
     #[derive(Debug)]
-    enum AstFrame<'a> {
+    enum AstFrame {
         Object {
-            entries: ObjectEntries<'a>,
-            current_key: Option<&'a str>,
+            entries: ObjectEntries,
+            current_key: Option<Range<usize>>,
         },
         Array {
-            items: Vec<Value<'a>>,
+            items: Vec<Value>,
         },
     }
 
-    impl<'a> AstVisitor<'a> {
+    impl AstVisitor {
         pub fn new() -> Self {
             Self {
                 stack: Vec::new(),
@@ -91,7 +135,7 @@ mod visitor {
             }
         }
 
-        fn last_emitted_mut(&mut self) -> &mut Value<'a> {
+        fn last_emitted_mut(&mut self) -> &mut Value {
             match self.stack.last_mut() {
                 None => self.result.as_mut().expect("must have emitted a value"),
                 Some(AstFrame::Array { items }) => items.last_mut().expect("must have item"),
@@ -101,9 +145,8 @@ mod visitor {
             }
         }
 
-        fn emit_value(&mut self, value: Value<'a>) {
+        fn emit_value(&mut self, value: Value) {
             match self.stack.last_mut() {
-                // top-level value
                 None => {
                     self.result = Some(value);
                 }
@@ -122,12 +165,12 @@ mod visitor {
             }
         }
 
-        pub fn finish(self) -> Option<Value<'a>> {
+        pub fn finish(self) -> Option<Value> {
             self.result
         }
     }
 
-    impl<'a> Visitor<'a> for AstVisitor<'a> {
+    impl<'a> Visitor<'a> for AstVisitor {
         fn on_object_open(&mut self) {
             self.stack.push(AstFrame::Object {
                 entries: ObjectEntries::new(),
@@ -135,9 +178,9 @@ mod visitor {
             });
         }
 
-        fn on_object_key(&mut self, key: &'a str) {
+        fn on_object_key(&mut self, range: Range<usize>, _key: &'a str) {
             if let Some(AstFrame::Object { current_key, .. }) = self.stack.last_mut() {
-                *current_key = Some(key);
+                *current_key = Some(range);
             } else {
                 unreachable!("must be in object for object key")
             }
@@ -175,22 +218,22 @@ mod visitor {
             self.emit_value(Value::Null);
         }
 
-        fn on_string(&mut self, s: &'a str) {
-            self.emit_value(Value::String(s));
+        fn on_string(&mut self, range: Range<usize>, _s: &'a str) {
+            self.emit_value(Value::String(range));
         }
 
-        fn on_mantissa(&mut self, mantissa: &'a str) {
+        fn on_mantissa(&mut self, range: Range<usize>, _mantissa: &'a str) {
             self.emit_value(Value::Number {
-                mantissa,
+                mantissa: range,
                 exponent: None,
             });
         }
 
-        fn on_exponent(&mut self, exponent: &'a str) {
-            let Value::Number { exponent: e, .. } = self.last_emitted_mut() else {
+        fn on_exponent(&mut self, range: Range<usize>, _exponent: &'a str) {
+            let Value::Number { exponent, .. } = self.last_emitted_mut() else {
                 unreachable!("exponent must follow mantissa")
             };
-            *e = Some(exponent);
+            *exponent = Some(range);
         }
 
         fn on_boolean(&mut self, b: bool) {
@@ -206,68 +249,58 @@ mod visitor {
 mod tests {
     use super::*;
 
-    fn kv_to_map<'a>(tuples: &[(&'a str, Value<'a>)]) -> Value<'a> {
-        Value::Object(tuples.to_vec().into())
+    fn range_of(source: &str, needle: &str) -> Range<usize> {
+        let start = source.find(needle).expect("needle in source");
+        start..start + needle.len()
+    }
+
+    fn make_obj(entries: Vec<(&str, Value)>, source: &str) -> Value {
+        let entries = entries
+            .into_iter()
+            .map(|(k, v)| (range_of(source, k), v))
+            .collect::<Vec<_>>();
+        Value::Object(ObjectEntries(entries))
     }
 
     #[test]
     fn empty_object() {
-        assert_eq!(parse_str("{}").unwrap(), kv_to_map(&[]));
+        let doc = Document::parse("{}").unwrap();
+        assert_eq!(doc.root(), &Value::Object(ObjectEntries::new()));
     }
 
     #[test]
     fn one_key_value_pair() {
+        let json = r#"{"hi":"bye"}"#;
+        let doc = Document::parse(json).unwrap();
         assert_eq!(
-            parse_str(r#"{"hi":"bye"}"#).unwrap(),
-            kv_to_map(&[("hi", Value::String("bye"))])
-        );
-    }
-
-    #[test]
-    fn nested_object() {
-        let nested = |val| kv_to_map(&[("rust", val)]);
-        assert_eq!(
-            parse_str(
-                r#"
-                {
-                    "rust": {
-                        "rust": {
-                            "rust": {
-                                "rust": "rust"
-                            }   
-                        }   
-                    }
-                }        
-            "#
-            )
-            .unwrap(),
-            nested(nested(nested(nested(Value::String("rust")))))
+            doc.root(),
+            &make_obj(vec![("hi", Value::String(range_of(json, "bye")))], json)
         );
     }
 
     #[rstest_reuse::template]
     #[rstest::rstest]
-    #[case("null", Value::Null)]
-    #[case("true", Value::Boolean(true))]
-    #[case("false", Value::Boolean(false))]
-    #[case("\"burger\"", Value::String("burger".into()))]
-    fn primitive_template(#[case] primitive: &str, #[case] expected: Value) {}
+    #[case("null", |_: &str| Value::Null)]
+    #[case("true", |_: &str| Value::Boolean(true))]
+    #[case("false", |_: &str| Value::Boolean(false))]
+    #[case("\"burger\"", |s: &str| Value::String(range_of(s, "burger")))]
+    fn primitive_template(#[case] primitive: &str, #[case] expected: fn(&str) -> Value) {}
 
     #[rstest_reuse::apply(primitive_template)]
-    fn primitive_object_value(#[case] primitive: &str, #[case] expected: Value) {
-        assert_eq!(
-            parse_str(&format!(
-                r#"{{
+    fn primitive_object_value(#[case] primitive: &str, #[case] expected: fn(&str) -> Value) {
+        let json = format!(
+            r#"{{
                 "rust": {primitive}
             }}"#
-            ))
-            .unwrap(),
-            kv_to_map(&[("rust", expected)])
-        )
+        );
+        let doc = Document::parse(&json).unwrap();
+        let want = make_obj(vec![("rust", expected(&json))], &json);
+        assert_eq!(doc.root(), &want);
     }
 
     #[rstest_reuse::apply(primitive_template)]
-    fn primitives(#[case] json: &str, #[case] expected: Value) {
-        assert_eq!(parse_str(json), Ok(expected));
+    fn primitives(#[case] json: &str, #[case] expected: fn(&str) -> Value) {
+        let doc = Document::parse(json).unwrap();
+        assert_eq!(doc.root(), &expected(json));
     }
 }

--- a/crates/parse/src/ast.rs
+++ b/crates/parse/src/ast.rs
@@ -2,44 +2,27 @@ use visitor::AstVisitor;
 
 use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
 
-#[derive(Debug, Clone, Default, Eq)]
-pub struct ObjectEntries<'a>(pub Vec<(&'a str, Value<'a>)>);
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObjectEntries(pub(crate) Vec<(Range<usize>, Value)>);
 
 impl<'a> ObjectEntries<'a> {
     pub fn new() -> Self {
         Self(Vec::new())
     }
 
-    pub fn push(&mut self, k: &'a str, v: Value<'a>) {
-        self.0.push((k, v));
-    }
-
-    pub fn get(&self, k: &'a str) -> Option<&Value<'a>> {
-        self.0.iter().find_map(|(k2, v)| (k == *k2).then_some(v))
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
+    pub fn push(&mut self, key_range: Range<usize>, v: Value) {
+        self.0.push((key_range, v));
     }
 
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.0.is_empty()
     }
-}
 
-impl<'a> From<Vec<(&'a str, Value<'a>)>> for ObjectEntries<'a> {
-    fn from(value: Vec<(&'a str, Value<'a>)>) -> Self {
-        ObjectEntries(value)
-    }
-}
-
-impl<'a> PartialEq for ObjectEntries<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
-        }
-
-        self.0.iter().all(|(k, v)| other.get(k) == Some(v))
+    pub(crate) fn find<'a>(&'a self, source: &str, key: &str) -> Option<&'a Value> {
+        self.0
+            .iter()
+            .find(|(kr, _)| &source[*kr] == key)
+            .map(|(_, v)| v)
     }
 }
 

--- a/crates/parse/src/check.rs
+++ b/crates/parse/src/check.rs
@@ -1,3 +1,5 @@
+use core::range::Range;
+
 use crate::{
     Result,
     tokens::TokenStream,
@@ -9,14 +11,14 @@ pub struct NoopVisitor;
 
 impl<'a> Visitor<'a> for NoopVisitor {
     fn on_object_open(&mut self) {}
-    fn on_object_key(&mut self, _key: &'a str) {}
+    fn on_object_key(&mut self, _range: Range<usize>, _key: &'a str) {}
     fn on_object_close(&mut self) {}
     fn on_array_open(&mut self) {}
     fn on_array_close(&mut self) {}
     fn on_null(&mut self) {}
-    fn on_string(&mut self, _value: &'a str) {}
-    fn on_mantissa(&mut self, _mantissa: &'a str) {}
-    fn on_exponent(&mut self, _exponent: &'a str) {}
+    fn on_string(&mut self, _range: Range<usize>, _value: &'a str) {}
+    fn on_mantissa(&mut self, _range: Range<usize>, _mantissa: &'a str) {}
+    fn on_exponent(&mut self, _range: Range<usize>, _exponent: &'a str) {}
     fn on_boolean(&mut self, _value: bool) {}
     fn on_object_key_val_delim(&mut self) {}
     fn on_item_delim(&mut self) {}

--- a/crates/parse/src/format.rs
+++ b/crates/parse/src/format.rs
@@ -4,9 +4,10 @@ pub mod serde;
 mod uglify;
 
 pub use prettify::{
-    FormatOptions, format_str, format_value, prettify_str, prettify_value, prettify_value_into,
+    FormatOptions, format_document, format_str, prettify_document, prettify_document_into,
+    prettify_str,
 };
-pub use uglify::{uglify_str, uglify_value, uglify_value_into};
+pub use uglify::{uglify_document, uglify_document_into, uglify_str};
 
 use crate::tokens::{FALSE, NULL, TRUE};
 

--- a/crates/parse/src/format/prettify.rs
+++ b/crates/parse/src/format/prettify.rs
@@ -1,9 +1,9 @@
-use core::iter;
+use core::{iter, range::Range};
 
 use crate::{
     Result,
-    ast::{Value, parse_str},
-    format::{LineEnding, join_into},
+    ast::{Document, Value},
+    format::LineEnding,
     tokens::{FALSE, NULL, TRUE},
 };
 
@@ -14,6 +14,8 @@ const COLON_LEN: usize = 1;
 const EXPONENT_MARKER_LEN: usize = 1;
 const BRACKET_PAIR_LEN: usize = 2;
 const BRACE_PAIR_LEN: usize = 2;
+
+type ObjectEntry = (Range<usize>, Value);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct FormatOptions {
@@ -119,48 +121,70 @@ impl FormatBuf {
 
 pub fn format_str(json: &str, options: FormatOptions, preferred_width: usize) -> Result<String> {
     let mut buf = FormatBuf::new(String::with_capacity(json.len()), options, preferred_width);
-    format_value_into(&mut buf, &parse_str(json)?, 0);
+    let doc = Document::parse(json)?;
+    format_document_value_into(&mut buf, &doc, doc.root(), 0);
     Ok(buf.into_inner())
 }
 
-fn number_len(mantissa: &str, exponent: Option<&str>) -> usize {
-    mantissa.len() + exponent.map(|e| EXPONENT_MARKER_LEN + e.len()).unwrap_or(0)
+use super::join_into;
+
+fn range_len(range: Range<usize>) -> usize {
+    range.end - range.start
 }
 
-fn format_value_into(buf: &mut FormatBuf, val: &Value, depth: usize) {
+fn number_len(mantissa: Range<usize>, exponent: Option<Range<usize>>) -> usize {
+    range_len(mantissa)
+        + if let Some(exponent) = exponent {
+            EXPONENT_MARKER_LEN + range_len(exponent)
+        } else {
+            0
+        }
+}
+
+fn format_document_value_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    val: &Value,
+    depth: usize,
+) {
     match val {
         Value::Null => buf.push_str(NULL),
-        Value::String(s) => buf.push_quoted(s),
+        Value::String(r) => buf.push_quoted(doc.slice(*r)),
         Value::Number { mantissa, exponent } => {
-            buf.push_str(mantissa);
+            buf.push_str(doc.slice(*mantissa));
             if let Some(exponent) = exponent {
                 buf.push('e');
-                buf.push_str(exponent);
+                buf.push_str(doc.slice(*exponent));
             }
         }
         Value::Object(entries) if entries.0.is_empty() => buf.push_str("{}"),
         Value::Object(entries) => {
-            if !len::should_expand(val, buf.available_bytes(), buf.delimiter_len()) {
-                compact_format_obj_into(buf, entries.0.as_slice(), depth);
+            if !len::should_expand(doc, val, buf.available_bytes(), buf.delimiter_len()) {
+                compact_format_obj_into(buf, doc, entries.0.as_slice(), depth);
             } else {
-                expanded_format_obj_into(buf, entries.0.as_slice(), depth);
+                expanded_format_obj_into(buf, doc, entries.0.as_slice(), depth);
             }
         }
         Value::Array(items) if items.is_empty() => buf.push_str("[]"),
         Value::Array(items) => {
-            if !len::should_expand(val, buf.available_bytes(), buf.delimiter_len()) {
-                compact_format_arr_into(buf, items, depth);
+            if !len::should_expand(doc, val, buf.available_bytes(), buf.delimiter_len()) {
+                compact_format_arr_into(buf, doc, items, depth);
             } else if items.iter().all(|v| matches!(v, Value::Number { .. })) {
-                fill_format_arr_into(buf, items, depth);
+                fill_format_arr_into(buf, doc, items, depth);
             } else {
-                expanded_format_arr_into(buf, items, depth);
+                expanded_format_arr_into(buf, doc, items, depth);
             }
         }
         Value::Boolean(b) => buf.push_str(if *b { TRUE } else { FALSE }),
     }
 }
 
-fn expanded_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
+fn expanded_format_arr_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    items: &[Value],
+    depth: usize,
+) {
     buf.push('[');
     buf.write_eol();
     join_into(
@@ -168,7 +192,7 @@ fn expanded_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) 
         items,
         |buf, val| {
             buf.write_indent(depth + 1);
-            format_value_into(buf, val, depth + 1)
+            format_document_value_into(buf, doc, val, depth + 1)
         },
         |buf, _| {
             buf.push(',');
@@ -180,15 +204,20 @@ fn expanded_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) 
     buf.push(']');
 }
 
-fn expanded_format_obj_into(buf: &mut FormatBuf, entries: &[(&str, Value)], depth: usize) {
+fn expanded_format_obj_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    entries: &[ObjectEntry],
+    depth: usize,
+) {
     buf.push('{');
     buf.write_eol();
     join_into(
         buf,
         entries.iter(),
-        |buf, (key, val)| {
+        |buf, (key_range, val)| {
             buf.write_indent(depth + 1);
-            write_object_entry_into(buf, key, val, depth + 1);
+            write_object_entry_into(buf, doc, key_range, val, depth + 1);
         },
         |buf, _| {
             buf.push(',');
@@ -200,7 +229,12 @@ fn expanded_format_obj_into(buf: &mut FormatBuf, entries: &[(&str, Value)], dept
     buf.push('}');
 }
 
-fn fill_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
+fn fill_format_arr_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    items: &[Value],
+    depth: usize,
+) {
     buf.push('[');
     buf.write_eol();
     buf.write_indent(depth + 1);
@@ -208,7 +242,7 @@ fn fill_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
         let Value::Number { mantissa, exponent } = item else {
             unreachable!("fill_format_arr_into called with non-Number item");
         };
-        let item_len = number_len(mantissa, *exponent);
+        let item_len = number_len(*mantissa, *exponent);
         if i > 0 {
             buf.push(',');
             let trailing_comma_len = usize::from(i + 1 < items.len());
@@ -219,19 +253,24 @@ fn fill_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
                 buf.write_key_val_delimiter();
             }
         }
-        format_value_into(buf, item, depth + 1);
+        format_document_value_into(buf, doc, item, depth + 1);
     }
     buf.write_eol();
     buf.write_indent(depth);
     buf.push(']');
 }
 
-fn compact_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
+fn compact_format_arr_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    items: &[Value],
+    depth: usize,
+) {
     buf.push('[');
     join_into(
         buf,
         items,
-        |buf, val| format_value_into(buf, val, depth + 1),
+        |buf, val| format_document_value_into(buf, doc, val, depth + 1),
         |buf, _| {
             buf.push(',');
             buf.write_key_val_delimiter();
@@ -240,20 +279,31 @@ fn compact_format_arr_into(buf: &mut FormatBuf, items: &[Value], depth: usize) {
     buf.push(']');
 }
 
-fn write_object_entry_into(buf: &mut FormatBuf, key: &str, val: &Value, depth: usize) {
-    buf.push_quoted(key);
+fn write_object_entry_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    key_range: &Range<usize>,
+    val: &Value,
+    depth: usize,
+) {
+    buf.push_quoted(doc.slice(*key_range));
     buf.push(':');
     buf.write_key_val_delimiter();
-    format_value_into(buf, val, depth);
+    format_document_value_into(buf, doc, val, depth);
 }
 
-fn compact_format_obj_into(buf: &mut FormatBuf, entries: &[(&str, Value)], depth: usize) {
+fn compact_format_obj_into<S: AsRef<str>>(
+    buf: &mut FormatBuf,
+    doc: &Document<S>,
+    entries: &[ObjectEntry],
+    depth: usize,
+) {
     buf.push('{');
     buf.write_key_val_delimiter();
     join_into(
         buf,
         entries.iter(),
-        |buf, (key, val)| write_object_entry_into(buf, key, val, depth + 1),
+        |buf, (key_range, val)| write_object_entry_into(buf, doc, key_range, val, depth + 1),
         |buf, _| {
             buf.push(',');
             buf.write_key_val_delimiter();
@@ -263,9 +313,13 @@ fn compact_format_obj_into(buf: &mut FormatBuf, entries: &[(&str, Value)], depth
     buf.push('}');
 }
 
-pub fn format_value(val: &Value, options: &FormatOptions, preferred_width: usize) -> String {
+pub fn format_document<S: AsRef<str>>(
+    doc: &Document<S>,
+    options: &FormatOptions,
+    preferred_width: usize,
+) -> String {
     let mut buf = FormatBuf::new(String::new(), *options, preferred_width);
-    format_value_into(&mut buf, val, 0);
+    format_document_value_into(&mut buf, doc, doc.root(), 0);
     buf.into_inner()
 }
 
@@ -273,13 +327,17 @@ pub fn prettify_str(json: &str, preferred_width: usize, line_ending: LineEnding)
     format_str(json, FormatOptions::prettify(line_ending), preferred_width)
 }
 
-pub fn prettify_value(val: &Value, preferred_width: usize, line_ending: LineEnding) -> String {
-    format_value(val, &FormatOptions::prettify(line_ending), preferred_width)
+pub fn prettify_document<S: AsRef<str>>(
+    doc: &Document<S>,
+    preferred_width: usize,
+    line_ending: LineEnding,
+) -> String {
+    format_document(doc, &FormatOptions::prettify(line_ending), preferred_width)
 }
 
-pub fn prettify_value_into(
+pub fn prettify_document_into<S: AsRef<str>>(
     buf: &mut String,
-    val: &Value,
+    doc: &Document<S>,
     preferred_width: usize,
     line_ending: LineEnding,
 ) {
@@ -288,7 +346,7 @@ pub fn prettify_value_into(
         FormatOptions::prettify(line_ending),
         preferred_width,
     );
-    format_value_into(&mut fmt_buf, val, 0);
+    format_document_value_into(&mut fmt_buf, doc, doc.root(), 0);
     *buf = fmt_buf.into_inner();
 }
 
@@ -302,8 +360,13 @@ mod len {
     };
 
     /// returns if the inline length of the value > limit or it finds a newline
-    pub fn should_expand(val: &Value, limit: usize, delimiter_len: usize) -> bool {
-        try_get_value_len(val, limit, delimiter_len).is_none()
+    pub fn should_expand<S: AsRef<str>>(
+        doc: &crate::ast::Document<S>,
+        val: &Value,
+        limit: usize,
+        delimiter_len: usize,
+    ) -> bool {
+        try_get_value_len(doc, val, limit, delimiter_len).is_none()
     }
 
     fn quoted_len(value: &str) -> usize {
@@ -314,32 +377,37 @@ mod len {
         COMMA_LEN + delimiter_len
     }
 
-    fn try_get_value_len(val: &Value<'_>, limit: usize, delimiter_len: usize) -> Option<usize> {
+    fn try_get_value_len<S: AsRef<str>>(
+        doc: &crate::ast::Document<S>,
+        val: &Value,
+        limit: usize,
+        delimiter_len: usize,
+    ) -> Option<usize> {
         fn within_limit(len: usize, limit: usize) -> bool {
             len <= limit
         }
 
         let len = match val {
             Value::Null => NULL.len(),
-            Value::String(s) => quoted_len(s),
-            Value::Number { mantissa, exponent } => number_len(mantissa, *exponent),
+            Value::String(r) => quoted_len(doc.slice(*r)),
+            Value::Number { mantissa, exponent } => number_len(*mantissa, *exponent),
             Value::Object(entries) => {
                 if entries.is_empty() {
                     BRACE_PAIR_LEN
                 } else {
                     let braces_len = BRACE_PAIR_LEN + (delimiter_len * 2);
                     let mut sum = braces_len;
-                    for (i, (key, value)) in entries.0.iter().enumerate() {
+                    for (i, (key_range, value)) in entries.0.iter().enumerate() {
                         if !within_limit(sum, limit) {
                             break;
                         }
                         if i > 0 {
                             sum += separated_item_prefix_len(delimiter_len);
                         }
-                        sum += quoted_len(key);
+                        sum += quoted_len(doc.slice(*key_range));
                         sum += COLON_LEN + delimiter_len;
                         let remaining = limit.saturating_sub(sum);
-                        let len = try_get_value_len(value, remaining, delimiter_len)?;
+                        let len = try_get_value_len(doc, value, remaining, delimiter_len)?;
                         sum += len;
                     }
                     sum
@@ -356,7 +424,7 @@ mod len {
                         sum += separated_item_prefix_len(delimiter_len);
                     }
                     let remaining = limit.saturating_sub(sum);
-                    let len = try_get_value_len(value, remaining, delimiter_len)?;
+                    let len = try_get_value_len(doc, value, remaining, delimiter_len)?;
                     sum += len;
                 }
                 sum

--- a/crates/parse/src/format/uglify.rs
+++ b/crates/parse/src/format/uglify.rs
@@ -1,9 +1,11 @@
+use core::range::Range;
+
 use crate::{
     Result,
-    ast::Value,
+    ast::Document,
     format::Emitter,
     tokens::TokenStream,
-    traverse::{Visitor, parse_tokens, parse_value},
+    traverse::{Visitor, parse_tokens, visit_document},
 };
 
 pub fn uglify_str(json: &str) -> Result<String> {
@@ -32,7 +34,7 @@ impl<'a> Visitor<'a> for UglifyEmitVisitor {
         self.emit_object_open();
     }
 
-    fn on_object_key(&mut self, key: &str) {
+    fn on_object_key(&mut self, _range: Range<usize>, key: &'a str) {
         self.emit_string(key);
     }
 
@@ -56,15 +58,15 @@ impl<'a> Visitor<'a> for UglifyEmitVisitor {
         self.emit_null();
     }
 
-    fn on_string(&mut self, s: &str) {
+    fn on_string(&mut self, _range: Range<usize>, s: &'a str) {
         self.emit_string(s);
     }
 
-    fn on_mantissa(&mut self, mantissa: &str) {
+    fn on_mantissa(&mut self, _range: Range<usize>, mantissa: &'a str) {
         self.emit_mantissa(mantissa);
     }
 
-    fn on_exponent(&mut self, exponent: &str) {
+    fn on_exponent(&mut self, _range: Range<usize>, exponent: &'a str) {
         self.emit_exponent(exponent);
     }
 
@@ -77,16 +79,16 @@ impl<'a> Visitor<'a> for UglifyEmitVisitor {
     }
 }
 
-pub fn uglify_value(val: &Value) -> String {
+pub fn uglify_document<S: AsRef<str>>(doc: &Document<S>) -> String {
     let mut visitor = UglifyEmitVisitor::default();
-    parse_value(val, &mut visitor);
+    visit_document(doc, &mut visitor);
     visitor.buf
 }
 
-pub fn uglify_value_into(buf: &mut String, val: &Value) {
+pub fn uglify_document_into<S: AsRef<str>>(buf: &mut String, doc: &Document<S>) {
     let mut visitor = UglifyEmitVisitor {
         buf: std::mem::take(buf),
     };
-    parse_value(val, &mut visitor);
+    visit_document(doc, &mut visitor);
     *buf = visitor.buf;
 }

--- a/crates/parse/src/tokens.rs
+++ b/crates/parse/src/tokens.rs
@@ -80,7 +80,7 @@ impl ErrorToken {
     pub fn new(tag: Token, range: Range<usize>, source: &str) -> Self {
         Self {
             tag,
-            content: source[range.start..range.end].into(),
+            content: source[range].into(),
         }
     }
 

--- a/crates/parse/src/traverse.rs
+++ b/crates/parse/src/traverse.rs
@@ -5,22 +5,21 @@ use core::range::Range;
 
 use crate::{
     Error, ErrorKind, Result,
-    ast::{ObjectEntries, Value},
     tokens::{ErrorToken, Token, TokenStream, TokenWithContext},
     traverse::{array::parse_array, object::parse_object},
 };
 
 pub trait Visitor<'a> {
     fn on_object_open(&mut self);
-    fn on_object_key(&mut self, key: &'a str);
+    fn on_object_key(&mut self, range: Range<usize>, key: &'a str);
     fn on_object_key_val_delim(&mut self);
     fn on_object_close(&mut self);
     fn on_array_open(&mut self);
     fn on_array_close(&mut self);
     fn on_null(&mut self);
-    fn on_string(&mut self, value: &'a str);
-    fn on_mantissa(&mut self, mantissa: &'a str);
-    fn on_exponent(&mut self, exponent: &'a str);
+    fn on_string(&mut self, range: Range<usize>, value: &'a str);
+    fn on_mantissa(&mut self, range: Range<usize>, mantissa: &'a str);
+    fn on_exponent(&mut self, range: Range<usize>, exponent: &'a str);
     fn on_boolean(&mut self, value: bool);
     fn on_item_delim(&mut self);
 }
@@ -51,18 +50,18 @@ pub fn parse_tokens<'a>(
             match t {
                 Token::String => {
                     let body = token_ctx.content_range();
-                    visitor.on_string(&text[body.start..body.end]);
+                    visitor.on_string(body, &text[body]);
                 }
                 Token::Mantissa => {
-                    visitor.on_mantissa(&text[range.start..range.end]);
+                    visitor.on_mantissa(range, &text[range]);
                     if let Some(TokenWithContext {
                         token: Token::Exponent,
-                        ..
+                        range: er,
                     }) = tokens.peek_token()?.copied()
                     {
                         let exp_ctx = tokens.next_token()?.expect("peek guaranteed");
-                        let er = exp_ctx.range;
-                        visitor.on_exponent(&text[er.start..er.end]);
+                        debug_assert_eq!(exp_ctx.range, er);
+                        visitor.on_exponent(er, &text[er]);
                     }
                 }
                 Token::Null => visitor.on_null(),
@@ -75,14 +74,7 @@ pub fn parse_tokens<'a>(
         }
         _ => {
             return Err(Error::new(
-                ErrorKind::ExpectedValue(
-                    None,
-                    crate::tokens::TokenOption(Some(ErrorToken::new(
-                        peeked.token,
-                        peeked.range,
-                        text,
-                    ))),
-                ),
+                ErrorKind::ExpectedValue(None, Some(peeked.token).into()),
                 peeked.range,
                 text,
             ));
@@ -132,14 +124,26 @@ fn join<V, T>(
     }
 }
 
-pub fn parse_value<'a>(val: &'a Value, visitor: &mut impl Visitor<'a>) {
+pub fn visit_document<'a, S: AsRef<str>>(
+    doc: &'a crate::ast::Document<S>,
+    visitor: &mut impl Visitor<'a>,
+) {
+    visit_value(doc, doc.root(), visitor);
+}
+
+fn visit_value<'a, S: AsRef<str>>(
+    doc: &'a crate::ast::Document<S>,
+    val: &crate::ast::Value,
+    visitor: &mut impl Visitor<'a>,
+) {
+    use crate::ast::{ObjectEntries, Value};
     match val {
         Value::Null => visitor.on_null(),
-        Value::String(s) => visitor.on_string(s),
+        Value::String(r) => visitor.on_string(*r, doc.slice(*r)),
         Value::Number { mantissa, exponent } => {
-            visitor.on_mantissa(mantissa);
+            visitor.on_mantissa(*mantissa, doc.slice(*mantissa));
             if let Some(exponent) = exponent {
-                visitor.on_exponent(exponent);
+                visitor.on_exponent(*exponent, doc.slice(*exponent));
             }
         }
         Value::Boolean(b) => visitor.on_boolean(*b),
@@ -148,10 +152,10 @@ pub fn parse_value<'a>(val: &'a Value, visitor: &mut impl Visitor<'a>) {
             join(
                 visitor,
                 items,
-                |visitor, (k, v)| {
-                    visitor.on_object_key(k);
+                |visitor, (kr, v)| {
+                    visitor.on_object_key(*kr, doc.slice(*kr));
                     visitor.on_object_key_val_delim();
-                    parse_value(v, visitor);
+                    visit_value(doc, v, visitor);
                 },
                 |visitor, _| visitor.on_item_delim(),
             );
@@ -162,9 +166,7 @@ pub fn parse_value<'a>(val: &'a Value, visitor: &mut impl Visitor<'a>) {
             join(
                 visitor,
                 items,
-                |visitor, val| {
-                    parse_value(val, visitor);
-                },
+                |visitor, val| visit_value(doc, val, visitor),
                 |visitor, _| visitor.on_item_delim(),
             );
             visitor.on_array_close();
@@ -175,36 +177,41 @@ pub fn parse_value<'a>(val: &'a Value, visitor: &mut impl Visitor<'a>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::parse_str;
+    use crate::ast::Document;
+
+    fn range_of(source: &str, needle: &str) -> Range<usize> {
+        let start = source.find(needle).expect("needle in source");
+        start..start + needle.len()
+    }
 
     #[derive(Debug, PartialEq, Eq)]
-    enum Event<'a> {
+    enum Event {
         ObjectOpen,
-        ObjectKey(&'a str),
+        ObjectKey(Range<usize>),
         ObjectKeyValDelim,
         ObjectClose,
         ArrayOpen,
         ArrayClose,
         Null,
-        String(&'a str),
-        Mantissa(&'a str),
-        Exponent(&'a str),
+        String(Range<usize>),
+        Mantissa(Range<usize>),
+        Exponent(Range<usize>),
         Boolean(bool),
         ItemDelim,
     }
 
     #[derive(Default)]
-    struct RecordingVisitor<'a> {
-        events: Vec<Event<'a>>,
+    struct RecordingVisitor {
+        events: Vec<Event>,
     }
 
-    impl<'a> Visitor<'a> for RecordingVisitor<'a> {
+    impl<'a> Visitor<'a> for RecordingVisitor {
         fn on_object_open(&mut self) {
             self.events.push(Event::ObjectOpen);
         }
 
-        fn on_object_key(&mut self, key: &'a str) {
-            self.events.push(Event::ObjectKey(key));
+        fn on_object_key(&mut self, range: Range<usize>, _key: &'a str) {
+            self.events.push(Event::ObjectKey(range));
         }
 
         fn on_object_key_val_delim(&mut self) {
@@ -227,16 +234,16 @@ mod tests {
             self.events.push(Event::Null);
         }
 
-        fn on_string(&mut self, value: &'a str) {
-            self.events.push(Event::String(value));
+        fn on_string(&mut self, range: Range<usize>, _value: &'a str) {
+            self.events.push(Event::String(range));
         }
 
-        fn on_mantissa(&mut self, mantissa: &'a str) {
-            self.events.push(Event::Mantissa(mantissa));
+        fn on_mantissa(&mut self, range: Range<usize>, _mantissa: &'a str) {
+            self.events.push(Event::Mantissa(range));
         }
 
-        fn on_exponent(&mut self, exponent: &'a str) {
-            self.events.push(Event::Exponent(exponent));
+        fn on_exponent(&mut self, range: Range<usize>, _exponent: &'a str) {
+            self.events.push(Event::Exponent(range));
         }
 
         fn on_boolean(&mut self, value: bool) {
@@ -249,37 +256,38 @@ mod tests {
     }
 
     #[test]
-    fn parse_value_matches_token_traversal_events() {
+    fn visit_document_matches_token_traversal_events() {
         let json = r#"{"a":["b",{"c":1e5}],"d":true}"#;
         let expected = vec![
             Event::ObjectOpen,
-            Event::ObjectKey("a"),
+            Event::ObjectKey(range_of(json, "a")),
             Event::ObjectKeyValDelim,
             Event::ArrayOpen,
-            Event::String("b"),
+            Event::String(range_of(json, "b")),
             Event::ItemDelim,
             Event::ObjectOpen,
-            Event::ObjectKey("c"),
+            Event::ObjectKey(range_of(json, "c")),
             Event::ObjectKeyValDelim,
-            Event::Mantissa("1"),
-            Event::Exponent("5"),
+            Event::Mantissa(range_of(json, "1")),
+            Event::Exponent(range_of(json, "5")),
             Event::ObjectClose,
             Event::ArrayClose,
             Event::ItemDelim,
-            Event::ObjectKey("d"),
+            Event::ObjectKey(range_of(json, "d")),
             Event::ObjectKeyValDelim,
             Event::Boolean(true),
             Event::ObjectClose,
         ];
 
-        let mut from_tokens = RecordingVisitor::default();
+        let mut from_tokens: RecordingVisitor = RecordingVisitor::default();
         parse_tokens(&mut TokenStream::new(json), json, true, &mut from_tokens).unwrap();
 
-        let ast = parse_str(json).unwrap();
+        let doc = Document::parse(json).unwrap();
         let mut from_ast = RecordingVisitor::default();
-        parse_value(&ast, &mut from_ast);
+        visit_document(&doc, &mut from_ast);
 
         assert_eq!(from_tokens.events, expected);
         assert_eq!(from_ast.events, expected);
+        assert_eq!(from_tokens.events, from_ast.events);
     }
 }

--- a/crates/parse/src/traverse/array.rs
+++ b/crates/parse/src/traverse/array.rs
@@ -107,6 +107,7 @@ impl ArrayState {
                 Some(TokenWithContext {
                     token: Token::ClosedSquareBracket,
                     range: closed_range,
+                    ..
                 }) => {
                     tokens.next_token()?;
 

--- a/crates/parse/src/traverse/object.rs
+++ b/crates/parse/src/traverse/object.rs
@@ -68,13 +68,15 @@ impl ObjectState {
             } => match (last_pair, tokens.next_token()?) {
                 (
                     _,
-                    Some(TokenWithContext {
-                        token: Token::ClosedCurlyBrace,
-                        range: closed_range,
-                    }),
+                    Some(
+                        ctx @ TokenWithContext {
+                            token: Token::ClosedCurlyBrace,
+                            ..
+                        },
+                    ),
                 ) => {
                     visitor.on_object_close();
-                    ObjectState::End(open_ctx.range.start..closed_range.end)
+                    ObjectState::End(open_ctx.range.start..ctx.range.end)
                 }
                 (
                     Some(_),
@@ -101,7 +103,7 @@ impl ObjectState {
                     ),
                 ) => {
                     let body = key_ctx.content_range();
-                    visitor.on_object_key(&text[body.start..body.end]);
+                    visitor.on_object_key(body, &text[body]);
                     ObjectState::Colon { key_ctx, open_ctx }
                 }
                 (Some(pair_span), maybe_token) => {
@@ -138,7 +140,7 @@ impl ObjectState {
                     },
                 ) => {
                     let body = key_ctx.content_range();
-                    visitor.on_object_key(&text[body.start..body.end]);
+                    visitor.on_object_key(body, &text[body]);
                     ObjectState::Colon { key_ctx, open_ctx }
                 }
                 maybe_token => {

--- a/tests/integration/format_ast.rs
+++ b/tests/integration/format_ast.rs
@@ -1,12 +1,12 @@
 use insta::assert_snapshot;
-use jjpwrgem_parse::{ast::parse_str, format::uglify_value};
+use jjpwrgem_parse::{ast::Document, format::uglify_document};
 
 use crate::{common::format_template, test_json::*};
 
 #[rstest_reuse::apply(format_template)]
 fn uglify(#[case] (name, input): (&str, &str)) {
-    let val = parse_str(input).unwrap();
-    let out = uglify_value(&val);
+    let doc = Document::parse(input).unwrap();
+    let out = uglify_document(&doc);
 
     assert_snapshot!(format!("uglify_{name}"), out);
 }

--- a/xtask/src/npm.rs
+++ b/xtask/src/npm.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, fs};
 
 use anyhow::{Context, Ok, Result, anyhow};
 use itertools::Itertools as _;
-use jjpwrgem_parse::format::LineEnding;
+use jjpwrgem_parse::{ast::Document, format::LineEnding};
 use package_json::PackageJson;
 
 use crate::npm::metadata::{
@@ -77,9 +77,8 @@ pub fn write_package_json() -> Result<()> {
     // I don't mind so much
     let compact_json =
         jjpwrgem_parse::format::serde::uglify_serializable(&package_json_from_env()?)?;
-    let ast =
-        jjpwrgem_parse::ast::parse_str(&compact_json).map_err(|err| anyhow!(err.to_string()))?;
-    let formatted_json = jjpwrgem_parse::format::prettify_value(&ast, 80, LineEnding::Lf);
+    let ast = Document::parse(compact_json.as_str()).map_err(|err| anyhow!(err.to_string()))?;
+    let formatted_json = jjpwrgem_parse::format::prettify_document(&ast, 80, LineEnding::Lf);
 
     let static_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../npm-template/package.json");
     fs::write(static_path, formatted_json)?;

--- a/xtask/src/plot.rs
+++ b/xtask/src/plot.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::{Context, Error, Result, anyhow, bail};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use jjpwrgem_parse::ast::{self, Value};
+use jjpwrgem_parse::ast::{self, Document, Value};
 use plotters::{
     coord::Shift,
     prelude::*,
@@ -26,24 +26,24 @@ struct BenchmarkResult {
     times: Vec<f64>,
 }
 
-impl<'a> TryFrom<&Value<'a>> for BenchmarkResult {
+impl TryFrom<(&Document<&str>, &Value)> for BenchmarkResult {
     type Error = Error;
 
-    fn try_from(item: &Value<'a>) -> std::result::Result<Self, Self::Error> {
+    fn try_from((doc, item): (&Document<&str>, &Value)) -> std::result::Result<Self, Self::Error> {
         let ast::Value::Object(entry) = item else {
             bail!("must be a JSON object");
         };
 
-        let command_value = entry
-            .get("command")
+        let command_value = doc
+            .get_object_value(entry, "command")
             .with_context(|| "missing 'command' field")?;
-        let ast::Value::String(value) = command_value else {
-            bail!("command must be a string");
-        };
-        let command = (*value).to_owned();
+        let command = doc
+            .as_str(command_value)
+            .with_context(|| "command must be a string")?
+            .to_owned();
 
-        let times_value = entry
-            .get("times")
+        let times_value = doc
+            .get_object_value(entry, "times")
             .with_context(|| "missing 'times' field")?;
         let ast::Value::Array(times_array) = times_value else {
             bail!("must be an array");
@@ -53,8 +53,8 @@ impl<'a> TryFrom<&Value<'a>> for BenchmarkResult {
             .iter()
             .enumerate()
             .map(|(time_index, time_value)| -> Result<f64> {
-                let parsed = time_value
-                    .to_f64()
+                let parsed = doc
+                    .parse_f64(time_value)
                     .with_context(|| format!("times[{time_index}] must be a number"))?;
                 Ok(parsed)
             })
@@ -65,14 +65,14 @@ impl<'a> TryFrom<&Value<'a>> for BenchmarkResult {
 }
 
 fn parse_benchmark_results(raw: &str) -> Result<Vec<BenchmarkResult>> {
-    let root = ast::parse_str(raw)
+    let doc = Document::parse(raw)
         .map_err(|err| anyhow!("failed to parse JSON with jjpwrgem parser: {err}"))?;
-    let ast::Value::Object(entries) = root else {
+    let ast::Value::Object(entries) = doc.root() else {
         bail!("benchmark data must be a JSON object");
     };
 
-    let results_value = entries
-        .get("results")
+    let results_value = doc
+        .get_object_value(entries, "results")
         .context("benchmark data missing 'results' field")?;
     let ast::Value::Array(items) = results_value else {
         bail!("'results' field must be an array");
@@ -82,7 +82,9 @@ fn parse_benchmark_results(raw: &str) -> Result<Vec<BenchmarkResult>> {
         .iter()
         .enumerate()
         .map(|(index, item)| -> Result<BenchmarkResult> {
-            item.try_into().with_context(|| format!("index: {index}"))
+            (&doc, item)
+                .try_into()
+                .with_context(|| format!("index: {index}"))
         })
         .collect()
 }


### PR DESCRIPTION
`Document` can own backing data instead of `Value`, allowing thread safety at the cost of slicing when formatting

Benches below show slight regressions in formatting since slicing moves to formatting. In practice this is 1-200 microseconds. Deser has greater regressions, but these are acceptable since this allows caching