### PR TITLE
ci: validate renovate config

### DIFF
--- a/.config/hk.pkl
+++ b/.config/hk.pkl
@@ -3,10 +3,6 @@ import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtin
 
 // Steps that mutate files. Run in pre-commit (with stash) and on `hk fix`.
 local fix_steps = new Mapping<String, Step> {
-  ["renovate-check"] {
-    glob = List(".github/renovate.json")
-    check = "mise run renovate-check"
-  }
   ["diet"] {
     fix = "mise run diet"
     stage = List("crates/**/Cargo.toml", "Cargo.toml")

--- a/.config/hk.pkl
+++ b/.config/hk.pkl
@@ -3,6 +3,10 @@ import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtin
 
 // Steps that mutate files. Run in pre-commit (with stash) and on `hk fix`.
 local fix_steps = new Mapping<String, Step> {
+  ["renovate-check"] {
+    glob = List(".github/renovate.json")
+    check = "mise run renovate-check"
+  }
   ["diet"] {
     fix = "mise run diet"
     stage = List("crates/**/Cargo.toml", "Cargo.toml")
@@ -20,6 +24,10 @@ local fix_steps = new Mapping<String, Step> {
 
 // Read-only steps. Run on pre-push and `hk check`.
 local check_steps = new Mapping<String, Step> {
+  ["renovate-check"] {
+    glob = List(".github/renovate.json")
+    check = "mise run renovate-check"
+  }
   ["format-check"] {
     check = "mise run format-check"
   }

--- a/.config/mise/conf.d/lint.toml
+++ b/.config/mise/conf.d/lint.toml
@@ -10,6 +10,7 @@ shellcheck = "0.11.0"
 "npm:knip" = "6.14.2"
 "npm:oxfmt" = "0.51.0"
 "npm:oxlint" = "1.66.0"
+"npm:renovate" = "42.99.0"
 
 [tasks.typos]
 run = "typos"
@@ -49,3 +50,6 @@ run = "cargo package -p bytes2chars -p jjpwrgem-parse -p jjpwrgem-ui -p jjpwrgem
 [tasks.tracey-check]
 description = "Verify spec rules have version bumps for any changed rule text"
 run = "tracey pre-commit"
+
+[tasks.renovate-check]
+run = "renovate-config-validator .github/renovate.json"

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -187,6 +187,10 @@ backend = "npm:oxlint"
 version = "3.8.3"
 backend = "npm:prettier"
 
+[[tools."npm:renovate"]]
+version = "42.99.0"
+backend = "npm:renovate"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"


### PR DESCRIPTION
## Summary
- add Renovate CLI as a mise npm tool
- add `renovate-check` for `.github/renovate.json`
- run the check through hk fix/check hooks so the consolidated verify workflow picks it up via `hk check --all`

## Validation
- `git diff --check upstream/main...HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/verify.yml"); puts "workflow yaml ok"'`
- `python3 -c 'import json,tomllib; json.load(open(".github/renovate.json")); tomllib.load(open(".config/mise/conf.d/lint.toml","rb")); tomllib.load(open(".config/mise/mise.lock","rb")); print("json and toml ok")'`
- `git diff upstream/main...HEAD | gitleaks stdin --no-banner --redact --exit-code 1`

Local limitation: `npm exec --yes --package renovate@42.99.0 -- renovate-config-validator .github/renovate.json` did not return output in this shell and was stopped, so I am not counting that as passed.

Fixes #229
