### PR TITLE
simplify parse exports

### DIFF
--- a/.config/mise/conf.d/release.toml
+++ b/.config/mise/conf.d/release.toml
@@ -14,7 +14,7 @@ run = [
 
 [tasks.publish-dry-run]
 description = "cargo publish --dry-run for a specific crate (e.g. mise run publish-dry-run bytes2chars)"
-run = 'cargo publish -q --dry-run -p "$@"'
+run = 'cargo publish -q --dry-run --no-verify -p "$@"'
 
 [tasks.release-binary]
 description = "Bump versions via release-plz and tag a binary release via cargo-release"

--- a/crates/cli/main.rs
+++ b/crates/cli/main.rs
@@ -15,7 +15,7 @@ use std::{
 use clap::Parser;
 pub use error::{Error, Result};
 use jjpwrgem_parse::{
-    error::diagnostics::Diagnostic,
+    diagnostics::Diagnostic,
     format::{self, LineEnding},
     validate_str,
 };

--- a/crates/cli/output.rs
+++ b/crates/cli/output.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use std::process::ExitCode;
 
-use jjpwrgem_parse::error::diagnostics::Diagnostic;
+use jjpwrgem_parse::diagnostics::Diagnostic;
 use jjpwrgem_ui::Style;
 
 pub struct Output {

--- a/crates/parse/src/ast.rs
+++ b/crates/parse/src/ast.rs
@@ -8,15 +8,15 @@ use crate::{Result, tokens::TokenStream, traverse::parse_tokens};
 pub struct ObjectEntries(pub(crate) Vec<(Range<usize>, Value)>);
 
 impl ObjectEntries {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(Vec::new())
     }
 
-    pub fn push(&mut self, key_range: Range<usize>, v: Value) {
+    pub(crate) fn push(&mut self, key_range: Range<usize>, v: Value) {
         self.0.push((key_range, v));
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 

--- a/crates/parse/src/diagnostics.rs
+++ b/crates/parse/src/diagnostics.rs
@@ -65,24 +65,6 @@ pub struct Diagnostic<'a> {
     pub source: Source<'a>,
 }
 
-impl<'a> Diagnostic<'a> {
-    pub fn new(
-        message: String,
-        context: Vec<Context<'a>>,
-        patches: Vec<Patch<'a>>,
-        source: Source<'a>,
-        range: Option<Range<usize>>,
-    ) -> Self {
-        Self {
-            message,
-            range,
-            context,
-            patches,
-            source,
-        }
-    }
-}
-
 fn error_source(error: &Error) -> Source<'_> {
     if error.source_name == "stdin" {
         Source::Stdin(error.source_text.as_str())

--- a/crates/parse/src/error.rs
+++ b/crates/parse/src/error.rs
@@ -1,5 +1,3 @@
-pub mod diagnostics;
-
 use core::{ops::Deref, range::Range};
 
 use displaydoc::Display;
@@ -104,7 +102,7 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
-    pub fn expected_entry_or_closed_delimiter(
+    pub(crate) fn expected_entry_or_closed_delimiter(
         open_ctx: TokenWithContext,
         found: TokenOption,
     ) -> Option<Self> {
@@ -130,15 +128,15 @@ fn closing_delimiter_for_open(token: Token) -> Option<JsonChar> {
 // box inner error for performance--a Rust enum is as large as the largest
 // variant so happy path case becomes 100s of bytes otherwise
 /// {0}
-pub struct Error(pub Box<ErrorInner>);
+pub struct Error(pub(crate) Box<ErrorInner>);
 
 #[derive(Debug, PartialEq, Eq, Display, Error, Clone)]
 /// {kind}
 pub struct ErrorInner {
     pub(crate) kind: ErrorKind,
-    range: Range<usize>,
-    source_text: String,
-    source_name: String,
+    pub(crate) range: Range<usize>,
+    pub(crate) source_text: String,
+    pub(crate) source_name: String,
 }
 
 impl From<ErrorInner> for Error {

--- a/crates/parse/src/format.rs
+++ b/crates/parse/src/format.rs
@@ -3,10 +3,7 @@ mod prettify;
 pub mod serde;
 mod uglify;
 
-pub use prettify::{
-    FormatOptions, format_document, format_str, prettify_document, prettify_document_into,
-    prettify_str,
-};
+pub use prettify::{prettify_document, prettify_document_into, prettify_str};
 pub use uglify::{uglify_document, uglify_document_into, uglify_str};
 
 use crate::tokens::{FALSE, NULL, TRUE};

--- a/crates/parse/src/format/prettify.rs
+++ b/crates/parse/src/format/prettify.rs
@@ -18,26 +18,14 @@ const BRACE_PAIR_LEN: usize = 2;
 type ObjectEntry = (Range<usize>, Value);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub struct FormatOptions {
+pub(crate) struct FormatOptions {
     key_val_delimiter: Option<(char, usize)>,
     indent: Option<(char, usize)>,
     line_ending: LineEnding,
 }
 
 impl FormatOptions {
-    pub fn new(
-        key_val_delimiter: Option<(char, usize)>,
-        indent: Option<(char, usize)>,
-        line_ending: LineEnding,
-    ) -> Self {
-        Self {
-            key_val_delimiter,
-            indent,
-            line_ending,
-        }
-    }
-
-    pub fn prettify(line_ending: LineEnding) -> Self {
+    pub(crate) fn prettify(line_ending: LineEnding) -> Self {
         Self {
             key_val_delimiter: Some((' ', 1)),
             indent: Some((' ', 2)),
@@ -119,7 +107,11 @@ impl FormatBuf {
     }
 }
 
-pub fn format_str(json: &str, options: FormatOptions, preferred_width: usize) -> Result<String> {
+pub(crate) fn format_str(
+    json: &str,
+    options: FormatOptions,
+    preferred_width: usize,
+) -> Result<String> {
     let mut buf = FormatBuf::new(String::with_capacity(json.len()), options, preferred_width);
     let doc = Document::parse(json)?;
     format_document_value_into(&mut buf, &doc, doc.root(), 0);
@@ -313,7 +305,7 @@ fn compact_format_obj_into<S: AsRef<str>>(
     buf.push('}');
 }
 
-pub fn format_document<S: AsRef<str>>(
+fn format_document<S: AsRef<str>>(
     doc: &Document<S>,
     options: &FormatOptions,
     preferred_width: usize,

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(portable_simd, new_range)]
 pub mod ast;
 mod check;
+pub mod diagnostics;
 pub mod error;
 pub mod format;
 pub mod tokens;

--- a/crates/parse/src/tokens.rs
+++ b/crates/parse/src/tokens.rs
@@ -1,13 +1,12 @@
-pub mod lexical;
+pub(crate) mod lexical;
 mod number;
 mod stream;
 mod string;
 
 use core::{fmt::Display, iter::Peekable, range::Range};
 
+pub use lexical::{JsonByte, JsonChar};
 pub use stream::TokenStream;
-
-use crate::tokens::lexical::{JsonByte, JsonChar};
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -27,7 +26,7 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn is_start_of_value(&self) -> bool {
+    pub(crate) fn is_start_of_value(self) -> bool {
         matches!(
             self,
             Token::OpenCurlyBrace
@@ -40,7 +39,7 @@ impl Token {
         )
     }
 
-    pub fn is_scalar(&self) -> bool {
+    pub(crate) fn is_scalar(self) -> bool {
         matches!(
             self,
             Token::String | Token::Null | Token::True | Token::False | Token::Mantissa
@@ -77,7 +76,7 @@ pub struct ErrorToken {
 }
 
 impl ErrorToken {
-    pub fn new(tag: Token, range: Range<usize>, source: &str) -> Self {
+    pub(crate) fn new(tag: Token, range: Range<usize>, source: &str) -> Self {
         Self {
             tag,
             content: source[range].into(),
@@ -146,11 +145,11 @@ pub struct TokenWithContext {
 }
 
 impl TokenWithContext {
-    pub fn new(token: Token, range: Range<usize>) -> Self {
+    pub(crate) fn new(token: Token, range: Range<usize>) -> Self {
         Self { token, range }
     }
 
-    pub fn content_range(&self) -> Range<usize> {
+    pub(crate) fn content_range(&self) -> Range<usize> {
         match self.token {
             Token::String => self.range.start + 1..self.range.end - 1,
             _ => self.range,
@@ -158,9 +157,9 @@ impl TokenWithContext {
     }
 }
 
-pub const NULL: &str = "null";
-pub const FALSE: &str = "false";
-pub const TRUE: &str = "true";
+pub(crate) const NULL: &str = "null";
+pub(crate) const FALSE: &str = "false";
+pub(crate) const TRUE: &str = "true";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CharWithContext(pub Range<usize>, pub JsonChar);
@@ -181,15 +180,15 @@ impl From<(usize, u8)> for ByteWithContext {
 }
 
 impl ByteWithContext {
-    pub fn range(&self) -> Range<usize> {
+    pub(crate) fn range(&self) -> Range<usize> {
         self.0..self.0 + 1
     }
 
-    pub fn as_token_with_context(&self) -> Option<TokenWithContext> {
+    pub(crate) fn as_token_with_context(&self) -> Option<TokenWithContext> {
         Some(TokenWithContext::new(self.1.as_token()?, self.range()))
     }
 
-    pub fn as_byte(&self) -> u8 {
+    pub(crate) fn as_byte(&self) -> u8 {
         self.1.0
     }
 }

--- a/crates/parse/src/tokens/lexical.rs
+++ b/crates/parse/src/tokens/lexical.rs
@@ -3,7 +3,7 @@ use core::{fmt::Display, range::RangeInclusive};
 use crate::tokens::{CharWithContext, Token};
 
 /// see [`JsonChar::is_whitespace`]
-pub fn trim_end_whitespace(s: &str) -> &str {
+pub(crate) fn trim_end_whitespace(s: &str) -> &str {
     let end = s
         .char_indices()
         .map(Into::<CharWithContext>::into)
@@ -21,11 +21,11 @@ pub struct JsonChar(pub char);
 pub struct JsonByte(pub u8);
 
 impl JsonByte {
-    pub fn is_whitespace(&self) -> bool {
+    pub(crate) fn is_whitespace(self) -> bool {
         matches!(self.0, b' ' | b'\t' | b'\n' | b'\r')
     }
 
-    pub fn as_token(&self) -> Option<Token> {
+    pub(crate) fn as_token(self) -> Option<Token> {
         let token = match self.0 {
             b'{' => Token::OpenCurlyBrace,
             b'}' => Token::ClosedCurlyBrace,
@@ -59,7 +59,7 @@ impl JsonChar {
     /// unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
     /// ```
     /// see [RFC 8249 section 7](https://datatracker.ietf.org/doc/html/rfc8259#section-7)
-    pub fn direct_escape(self) -> Option<&'static str> {
+    pub(crate) fn direct_escape(self) -> Option<&'static str> {
         match self.0 {
             '"' => Some(r#"\""#),
             '\\' => Some(r"\\"),
@@ -73,30 +73,31 @@ impl JsonChar {
         }
     }
 
-    pub fn minimal_escape(self) -> Option<&'static str> {
+    #[cfg(any(test, feature = "serde"))]
+    pub(crate) fn minimal_escape(self) -> Option<&'static str> {
         self.direct_escape().filter(|escaped| *escaped != r"\/")
     }
 
-    pub fn escape(self) -> String {
+    pub(crate) fn escape(self) -> String {
         match self.direct_escape() {
             Some(escaped) => escaped.into(),
             None => format!("\\u{:04X}", u32::from(self.0)),
         }
     }
 
-    pub fn is_hexdigit(&self) -> bool {
+    pub(crate) fn is_hexdigit(self) -> bool {
         self.0.is_ascii_hexdigit()
     }
 
-    pub fn can_be_escaped_directly(&self) -> bool {
+    pub(crate) fn can_be_escaped_directly(self) -> bool {
         matches!(self.0, '"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't')
     }
 
     /// See [RFC 8259, Section 7](https://datatracker.ietf.org/doc/html/rfc8259#section-7)
-    pub const CONTROL_RANGE: RangeInclusive<char> = '\u{0000}'..='\u{001F}';
+    pub(crate) const CONTROL_RANGE: RangeInclusive<char> = '\u{0000}'..='\u{001F}';
 
     /// see [`Self::CONTROL_RANGE`]
-    pub fn is_control(&self) -> bool {
+    pub(crate) fn is_control(self) -> bool {
         Self::CONTROL_RANGE.contains(&self.0)
     }
 
@@ -109,7 +110,7 @@ impl JsonChar {
     ///         %x0A /              ; Line feed or New line
     ///         %x0D )              ; Carriage return
     /// ```
-    pub fn is_whitespace(&self) -> bool {
+    pub(crate) fn is_whitespace(self) -> bool {
         matches!(self.0, ' ' | '\t' | '\n' | '\r')
     }
 
@@ -126,7 +127,7 @@ impl JsonChar {
     /// name-separator  = ws %x3A ws  ; : colon
     /// value-separator = ws %x2C ws  ; , comma
     /// ```
-    pub fn is_structural(&self) -> bool {
+    pub(crate) fn is_structural(self) -> bool {
         matches!(self.0, '{' | '}' | '[' | ']' | ':' | ',')
     }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,5 +1,5 @@
 use annotate_snippets::{Renderer, renderer::DecorStyle};
-use jjpwrgem_parse::error::diagnostics::Diagnostic;
+use jjpwrgem_parse::diagnostics::Diagnostic;
 
 mod pretty;
 

--- a/crates/ui/src/pretty.rs
+++ b/crates/ui/src/pretty.rs
@@ -1,6 +1,6 @@
 mod diagnostic {
     use annotate_snippets::{Annotation, AnnotationKind, Group, Level, Snippet};
-    use jjpwrgem_parse::error::diagnostics::{Context, Diagnostic, Patch, Source};
+    use jjpwrgem_parse::diagnostics::{Context, Diagnostic, Patch, Source};
     fn patch_to_patch(patch: Patch<'_>) -> annotate_snippets::Patch<'_> {
         annotate_snippets::Patch::new(patch.span.into(), patch.replacement)
     }


### PR DESCRIPTION
- **deprecated!: flatten parse module hierarchy and tighten internal visibility**
- **chore(ci): don't verify against published packages for release checks**
