### PR TITLE
chore(ci): narrow dist's workflow trigger tag

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 paths:
-  .github/workflows/jjp-release.yml:
+  .github/workflows/jjpwrgem-v-release.yml:
     ignore:
       - ".+"

--- a/.github/workflows/jjpwrgem-v-release.yml
+++ b/.github/workflows/jjpwrgem-v-release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - 'jjp**[0-9]+.[0-9]+.[0-9]+*'
+      - 'jjpwrgem-v**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,7 @@ tests/conformance
 xtask/bench/data
 benches/docker/data
 benches/docker/output/
-.github/workflows/jjp-release.yml
+.github/workflows/jjpwrgem-v-release.yml
 CHANGELOG.md
 pnpm-lock.yaml
 out

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,7 +22,7 @@ install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
 # A prefix git tags must include for dist to care about them
-tag-namespace = "jjp"
+tag-namespace = "jjpwrgem-v"
 # Host jobs to run in CI
 host-jobs = ["./host-npm"]
 # Publish jobs to run in CI

--- a/renovate.json
+++ b/renovate.json
@@ -107,7 +107,7 @@
     }
   ],
   "ignorePaths": [
-    ".github/workflows/jjp-release.yml",
+    ".github/workflows/jjpwrgem-v-release.yml",
     "npm-packages/jjpwrgem-vscode/**",
     "npm-template/package.json"
   ],


### PR DESCRIPTION
It was double triggering releases, so this should run binary releases only for the main crate