### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bytes2chars",
  "displaydoc",
@@ -1028,7 +1028,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "annotate-snippets",
  "jjpwrgem-parse",

--- a/crates/parse/CHANGELOG.md
+++ b/crates/parse/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.0...jjpwrgem-parse-v0.12.1) - 2026-05-23
+
+### Fixed
+
+- *(deps)* loosen dependency versions
+
 ## [0.12.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.11.1...jjpwrgem-parse-v0.12.0) - 2026-05-23
 
 ### Deprecated

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 description = "JSON parser and formatter with rich errors"
 license = "MIT"

--- a/crates/ui/CHANGELOG.md
+++ b/crates/ui/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-ui-v0.3.0...jjpwrgem-ui-v0.3.1) - 2026-05-23
+
+### Fixed
+
+- *(deps)* loosen dependency versions
+
 ## [0.3.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-ui-v0.2.0...jjpwrgem-ui-v0.3.0) - 2026-05-23
 
 ### Deprecated

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-ui"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "renders jjpwrgem diagnostics"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `jjpwrgem-parse`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `jjpwrgem-ui`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `jjpwrgem-parse`

<blockquote>

## [0.12.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.0...jjpwrgem-parse-v0.12.1) - 2026-05-23

### Fixed

- *(deps)* loosen dependency versions
</blockquote>

## `jjpwrgem-ui`

<blockquote>

## [0.3.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-ui-v0.3.0...jjpwrgem-ui-v0.3.1) - 2026-05-23

### Fixed

- *(deps)* loosen dependency versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).