### PR TITLE
fix(ci): add cargo component, setup-rust action, npm workflow_dispatch

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,10 @@
+name: Rust toolchain and cache setup
+description: Install Rust toolchain from rust-toolchain.toml and configure dependency caching
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust toolchain
+      run: rustup toolchain install --no-self-update
+      shell: bash
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/host-npm.yml
+++ b/.github/workflows/host-npm.yml
@@ -7,9 +7,16 @@ on:
         description: Dist release plan JSON payload
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: Publish as prerelease (--tag alpha)?
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   host:
@@ -21,13 +28,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - uses: ./.github/actions/setup-mise
-      - name: Generate npm package manifest
-        run: mise run package-json
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -41,7 +41,28 @@ jobs:
           npm pack ./npm-template --pack-destination ./npm
 
       - name: Upload npm package artifact
+        if: github.event_name == 'workflow_call'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ github.ref_name }}-npm-package.tgz
           path: ./npm/*.tgz
+
+      - name: Publish npm package
+        if: github.event_name == 'workflow_dispatch'
+        working-directory: npm
+        run: |
+          set -euo pipefail
+          tarball=$(find . -maxdepth 1 -name '*.tgz' -print | head -n1 || true)
+          if [ -z "${tarball}" ]; then
+            echo "No tarball (*.tgz) found in $(pwd)"
+            ls -la
+            exit 1
+          fi
+          echo "Publishing ${tarball}"
+          tag_args=()
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            tag_args=(--tag alpha)
+          fi
+          npm publish --access public --provenance "${tag_args[@]}" "${tarball}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,27 +25,24 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-mise
-      - name: Configure Dependency Caching
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: mise exec -- hk check --all
 
   build-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Configure Dependency Caching
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: ./.github/actions/setup-rust
       - run: cargo build --release --verbose
 
   test-vscode:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-mise
-      - name: Configure Dependency Caching
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: mise run vscode-bin
       - uses: ./.github/actions/setup-node
       - run: /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo "Started xvfb"

--- a/npm-packages/jjpwrgem-vscode/src/test/extension.test.ts
+++ b/npm-packages/jjpwrgem-vscode/src/test/extension.test.ts
@@ -50,7 +50,7 @@ suite("Extension Smoke Tests", function () {
     const formatted = editor.document.getText();
     assert.equal(
       formatted.trim(),
-      '{\n  "foo": "bar"\n}',
+      '{ "foo": "bar" }',
       "Formatted document should contain expected JSON keys",
     );
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,11 @@
 [toolchain]
 channel = "nightly-2026-05-22"
 profile = "minimal"
-components = ["rustfmt", "clippy", "rust-src", "rust-analyzer", "llvm-tools"]
+components = [
+  "cargo",
+  "rustfmt",
+  "clippy",
+  "rust-src",
+  "rust-analyzer",
+  "llvm-tools",
+]


### PR DESCRIPTION
Setup rust to the correct toolchain and allow publishing npm alone