### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.0...jjpwrgem-v0.6.1) - 2026-05-24
+
+### Added
+
+- add lsp with diagnostics, formatting, and code actions
+
+### Deprecated
+
+- deprecated!(parse): removed line and column numbers from error and display impl
+
+### Fixed
+
+- set limit of 128 nesting depth
+- support utf16 and utf8 in LSP
+
+### Tests
+
+- fuzz json parsing
+
 ## [0.6.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.5.5...jjpwrgem-v0.6.0) - 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jjpwrgem"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anstream",
  "bytes2chars",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-lsp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dashmap",
  "jjpwrgem-parse",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "bytes2chars",
  "displaydoc",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-ui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "annotate-snippets",
  "jjpwrgem-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 authors.workspace = true
 keywords = ["parser", "formatter", "json", "linter"]
@@ -50,7 +50,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.dependencies]
-jjpwrgem-parse = { path = "crates/parse", version = "0.12" }
+jjpwrgem-parse = { path = "crates/parse", version = "0.13" }
 jjpwrgem-ui = { path = "crates/ui", version = "0.3" }
 displaydoc = "0.2"
 thiserror = "2"

--- a/crates/lsp/CHANGELOG.md
+++ b/crates/lsp/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.0...jjpwrgem-lsp-v0.1.1) - 2026-05-24
+
+### Added
+
+- add lsp with diagnostics, formatting, and code actions
+
+### Deprecated
+
+- deprecated!(parse): removed line and column numbers from error and display impl
+
+### Fixed
+
+- support utf16 and utf8 in LSP

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-lsp"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 description = "JSON language server with rich errors"

--- a/crates/parse/CHANGELOG.md
+++ b/crates/parse/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.1...jjpwrgem-parse-v0.13.0) - 2026-05-24
+
+### Fixed
+
+- set limit of 128 nesting depth
+
 ## [0.12.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.0...jjpwrgem-parse-v0.12.1) - 2026-05-23
 
 ### Fixed

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.12.1"
+version = "0.13.0"
 edition.workspace = true
 authors.workspace = true
 description = "JSON parser and formatter with rich errors"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-ui"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 authors.workspace = true
 description = "renders jjpwrgem diagnostics"

--- a/npm-template/npm-shrinkwrap.json
+++ b/npm-template/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jjpwrgem",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-template/package.json
+++ b/npm-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "description": "jjpwrgem json parser with really good error messages",
   "keywords": [
@@ -32,7 +32,7 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.6.0",
+  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.6.1",
   "glibcMinimum": {
     "major": 2,
     "series": 35


### PR DESCRIPTION



## 🤖 New release

* `jjpwrgem-parse`: 0.12.1 -> 0.13.0 (⚠ API breaking changes)
* `jjpwrgem-lsp`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `jjpwrgem`: 0.6.0 -> 0.6.1
* `jjpwrgem-ui`: 0.3.1 -> 0.3.2

### ⚠ `jjpwrgem-parse` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ErrorKind:NestingTooDeep in /tmp/.tmpA2H9bk/JJPWRGEM/crates/parse/src/error.rs:103
  variant ErrorKind:NestingTooDeep in /tmp/.tmpA2H9bk/JJPWRGEM/crates/parse/src/error.rs:103
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jjpwrgem-parse`

<blockquote>

## [0.13.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.1...jjpwrgem-parse-v0.13.0) - 2026-05-24

### Fixed

- set limit of 128 nesting depth
</blockquote>

## `jjpwrgem-lsp`

<blockquote>

## [0.1.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.0...jjpwrgem-lsp-v0.1.1) - 2026-05-24

### Added

- add lsp with diagnostics, formatting, and code actions

### Deprecated

- deprecated!(parse): removed line and column numbers from error and display impl

### Fixed

- support utf16 and utf8 in LSP
</blockquote>

## `jjpwrgem`

<blockquote>

## [0.6.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.0...jjpwrgem-v0.6.1) - 2026-05-24

### Added

- add lsp with diagnostics, formatting, and code actions

### Deprecated

- deprecated!(parse): removed line and column numbers from error and display impl

### Fixed

- set limit of 128 nesting depth
- support utf16 and utf8 in LSP

### Tests

- fuzz json parsing
</blockquote>

## `jjpwrgem-ui`

<blockquote>

## [0.3.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-ui-v0.3.0...jjpwrgem-ui-v0.3.1) - 2026-05-23

### Fixed

- *(deps)* loosen dependency versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).