### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.1...jjpwrgem-v0.6.2) - 2026-05-25
+
+### Fixed
+
+- out of bounds index on multibyte error source
+
 ## [0.6.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.0...jjpwrgem-v0.6.1) - 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jjpwrgem"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anstream",
  "bytes2chars",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bytes2chars",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 authors.workspace = true
 keywords = ["parser", "formatter", "json", "linter"]

--- a/crates/parse/CHANGELOG.md
+++ b/crates/parse/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.13.0...jjpwrgem-parse-v0.13.1) - 2026-05-25
+
+### Fixed
+
+- out of bounds index on multibyte error source
+
 ## [0.13.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.12.1...jjpwrgem-parse-v0.13.0) - 2026-05-24
 
 ### Fixed

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 authors.workspace = true
 description = "JSON parser and formatter with rich errors"

--- a/npm-template/npm-shrinkwrap.json
+++ b/npm-template/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jjpwrgem",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-template/package.json
+++ b/npm-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "description": "jjpwrgem json parser with really good error messages",
   "keywords": [
@@ -32,7 +32,7 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.6.1",
+  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.6.2",
   "glibcMinimum": {
     "major": 2,
     "series": 35


### PR DESCRIPTION



## 🤖 New release

* `jjpwrgem-parse`: 0.13.0 -> 0.13.1 (✓ API compatible changes)
* `jjpwrgem`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jjpwrgem-parse`

<blockquote>

## [0.13.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.13.0...jjpwrgem-parse-v0.13.1) - 2026-05-25

### Fixed

- out of bounds index on multibyte error source
</blockquote>

## `jjpwrgem`

<blockquote>

## [0.6.2](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.1...jjpwrgem-v0.6.2) - 2026-05-25

### Fixed

- out of bounds index on multibyte error source
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).