### PR TITLE
refactor: remove thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,7 +1095,6 @@ dependencies = [
  "proptest",
  "rstest",
  "rstest_reuse",
- "thiserror",
 ]
 
 [[package]]
@@ -1118,7 +1117,6 @@ dependencies = [
  "rstest",
  "rstest_reuse",
  "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ exclude = ["fuzz"]
 jjpwrgem-parse = { path = "crates/parse", version = "0.13" }
 jjpwrgem-ui = { path = "crates/ui", version = "0.3" }
 displaydoc = "0.2"
-thiserror = "2"
 rstest = "0.26"
 rstest_reuse = "0.7"
 bytes2chars = { version = "0.2", path = "crates/bytes2chars" }
@@ -66,7 +65,6 @@ displaydoc = { workspace = true }
 jjpwrgem-parse = { workspace = true }
 jjpwrgem-ui = { workspace = true }
 lsp = { workspace = true }
-thiserror = { workspace = true }
 
 # fixes erroneous clippy warnings in 1.92
 [patch.crates-io]

--- a/crates/cli/error.rs
+++ b/crates/cli/error.rs
@@ -1,16 +1,17 @@
 use displaydoc::Display;
 use jjpwrgem_ui::BasicErrorMessage;
-use thiserror::Error;
 
 use crate::{docs::strip_front_matter, get_docs_snapshot};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Display, Debug, PartialEq, Eq, Clone, Error)]
+#[derive(Display, Debug, PartialEq, Eq, Clone)]
 pub enum Error {
     /// expected non empty input from stdin
     NonEmptyStdinRequired,
 }
+
+impl std::error::Error for Error {}
 
 impl Error {
     #[expect(

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["parser-implementations", "text-processing"]
 bytes2chars = { workspace = true }
 displaydoc = { workspace = true }
 serde = { version = "1.0.228", optional = true, features = ["derive"] }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/parse/src/error.rs
+++ b/crates/parse/src/error.rs
@@ -1,7 +1,6 @@
 use core::{ops::Deref, range::Range};
 
 use displaydoc::Display;
-use thiserror::Error;
 
 use crate::tokens::{
     CharWithContext, ErrorToken, JsonCharOption, Token, TokenOption, TokenWithContext,
@@ -126,13 +125,15 @@ fn closing_delimiter_for_open(token: Token) -> Option<JsonChar> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Display, Error, Clone)]
+#[derive(Debug, PartialEq, Eq, Display, Clone)]
 // box inner error for performance--a Rust enum is as large as the largest
 // variant so happy path case becomes 100s of bytes otherwise
 /// {0}
 pub struct Error(pub(crate) Box<ErrorInner>);
 
-#[derive(Debug, PartialEq, Eq, Display, Error, Clone)]
+impl std::error::Error for Error {}
+
+#[derive(Debug, PartialEq, Eq, Display, Clone)]
 /// {kind}
 pub struct ErrorInner {
     pub(crate) kind: ErrorKind,


### PR DESCRIPTION
It was only used for the Error derivation, so wasn't worth it