### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.3...jjpwrgem-v0.7.0) - 2026-06-01
+
+### Added
+
+- *(cli)* [**breaking**] replace --json-lines flag with --parser <type>
+- *(parse)* [**breaking**] builders and structs for configurations
+- [**breaking**] add range to value struct and visitor methods
+
+### Deprecated
+
+- *(cli)* [**breaking**] remove cr line ending option
+
 ## [0.6.3](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.2...jjpwrgem-v0.6.3) - 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,7 +1107,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jjpwrgem"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anstream",
  "bytes2chars",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-lsp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dashmap",
  "jjpwrgem-parse",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-parse"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "bon",
  "bytes2chars",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "annotate-snippets",
  "jjpwrgem-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.6.3"
+version = "0.7.0"
 edition.workspace = true
 authors.workspace = true
 keywords = ["parser", "formatter", "json", "linter"]
@@ -50,7 +50,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.dependencies]
-jjpwrgem-parse = { path = "crates/parse", version = "0.13" }
+jjpwrgem-parse = { path = "crates/parse", version = "0.14" }
 jjpwrgem-ui = { path = "crates/ui", version = "0.3" }
 displaydoc = "0.2.6"
 rstest = "0.26"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-lsp"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 description = "JSON language server with rich errors"

--- a/crates/parse/CHANGELOG.md
+++ b/crates/parse/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.13.2...jjpwrgem-parse-v0.14.0) - 2026-06-01
+
+### Added
+
+- *(cli)* [**breaking**] replace --json-lines flag with --parser <type>
+- *(parse)* [**breaking**] builders and structs for configurations
+- [**breaking**] add range to value struct and visitor methods
+
+### Deprecated
+
+- *(cli)* [**breaking**] remove cr line ending option
+
 ## [0.13.2](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.13.1...jjpwrgem-parse-v0.13.2) - 2026-05-26
 
 ### Added

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-parse"
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "JSON parser and formatter with rich errors"

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-ui"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 authors.workspace = true
 description = "renders jjpwrgem diagnostics"

--- a/npm-template/npm-shrinkwrap.json
+++ b/npm-template/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jjpwrgem",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-template/package.json
+++ b/npm-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jjpwrgem",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "private": false,
   "description": "jjpwrgem json parser with really good error messages",
   "keywords": [
@@ -32,7 +32,7 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.6.3",
+  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.7.0",
   "glibcMinimum": {
     "major": 2,
     "series": 35


### PR DESCRIPTION



## 🤖 New release

* `jjpwrgem-parse`: 0.13.2 -> 0.14.0 (⚠ API breaking changes)
* `jjpwrgem`: 0.6.3 -> 0.7.0
* `jjpwrgem-ui`: 0.3.2 -> 0.3.3
* `jjpwrgem-lsp`: 0.1.1 -> 0.1.2

### ⚠ `jjpwrgem-parse` breaking changes

```text
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant Value::Object in /tmp/.tmpfwaA1B/JJPWRGEM/crates/parse/src/ast.rs:40
  field 1 of variant Value::Array in /tmp/.tmpfwaA1B/JJPWRGEM/crates/parse/src/ast.rs:41
  field 1 of variant Value::Boolean in /tmp/.tmpfwaA1B/JJPWRGEM/crates/parse/src/ast.rs:42

--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant Value::Null in /tmp/.tmpfwaA1B/JJPWRGEM/crates/parse/src/ast.rs:33

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant LineEnding::Cr, previously in file /tmp/.tmpPcF2XZ/jjpwrgem-parse/src/format.rs:31

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  jjpwrgem_parse::jsonlines::format now takes 2 parameters instead of 1, in /tmp/.tmpfwaA1B/JJPWRGEM/crates/parse/src/jsonlines.rs:53
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jjpwrgem-parse`

<blockquote>

## [0.14.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-parse-v0.13.2...jjpwrgem-parse-v0.14.0) - 2026-06-01

### Added

- *(cli)* [**breaking**] replace --json-lines flag with --parser <type>
- *(parse)* [**breaking**] builders and structs for configurations
- [**breaking**] add range to value struct and visitor methods

### Deprecated

- *(cli)* [**breaking**] remove cr line ending option
</blockquote>

## `jjpwrgem`

<blockquote>

## [0.7.0](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.6.3...jjpwrgem-v0.7.0) - 2026-06-01

### Added

- *(cli)* [**breaking**] replace --json-lines flag with --parser <type>
- *(parse)* [**breaking**] builders and structs for configurations
- [**breaking**] add range to value struct and visitor methods

### Deprecated

- *(cli)* [**breaking**] remove cr line ending option
</blockquote>

## `jjpwrgem-ui`

<blockquote>

## [0.3.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-ui-v0.3.0...jjpwrgem-ui-v0.3.1) - 2026-05-23

### Fixed

- *(deps)* loosen dependency versions
</blockquote>

## `jjpwrgem-lsp`

<blockquote>

## [0.1.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.0...jjpwrgem-lsp-v0.1.1) - 2026-05-24

### Added

- add lsp with diagnostics, formatting, and code actions

### Deprecated

- deprecated!(parse): removed line and column numbers from error and display impl

### Fixed

- support utf16 and utf8 in LSP
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).