### PR TITLE
chore(ci): fix caching for mise deps. always install all tools to cache across runs

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,14 +1,12 @@
 name: mise setup
-description: Install mise and cargo-binstall so mise auto-installs cargo:* tools on demand
+description: Install and cache mise tools
 
 runs:
   using: composite
   steps:
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-      with:
-        install: false
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
     - uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2.77.3
       with:
         tool: cargo-binstall
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
+      - uses: ./.github/actions/setup-rust
       - uses: ./.github/actions/setup-mise
       - name: Configure Dependency Caching
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1


### PR DESCRIPTION
All tools are installed when running any `mise` command, so may as well cache them. Pulling from cache seems to take 10 seconds as opposed to around 1 minute