### PR TITLE
feat(parse)!: builders and structs for configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1138,7 @@ dependencies = [
 name = "jjpwrgem-parse"
 version = "0.13.2"
 dependencies = [
+ "bon",
  "bytes2chars",
  "displaydoc",
  "rstest",

--- a/benches/benches/json_jsonlines.rs
+++ b/benches/benches/json_jsonlines.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use jjpwrgem_parse::jsonlines;
+use jjpwrgem_parse::{format::LineEnding, jsonlines};
 
 fn bench_jsonlines_format(c: &mut Criterion) {
     let data = std::fs::read_to_string(
@@ -12,7 +12,7 @@ fn bench_jsonlines_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("jsonlines_format");
     group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function(BenchmarkId::new("jjpwrgem", "logs"), |b| {
-        b.iter(|| jsonlines::format(black_box(&data)).unwrap())
+        b.iter(|| jsonlines::format(black_box(&data), LineEnding::Lf).unwrap())
     });
     group.finish();
 }

--- a/benches/lsp/README.md
+++ b/benches/lsp/README.md
@@ -16,9 +16,9 @@ Note: memory values are RSS (resident set size), shown in megabytes.
 
 | method           | jjpwrgem        | vscode-json       |
 | ---------------- | --------------- | ----------------- |
-| initialize       | 14.5ms (4.6 MB) | 143.9ms (71.5 MB) |
-| diagnostic       | 0.2ms (4.8 MB)  | 506.0ms (71.6 MB) |
-| formatting       | 0.2ms (4.5 MB)  | 0.5ms (71.0 MB)   |
+| initialize       | 12.5ms (4.6 MB) | 149.3ms (71.0 MB) |
+| diagnostic       | 0.2ms (4.6 MB)  | 509.6ms (71.3 MB) |
+| formatting       | 0.2ms (4.5 MB)  | 0.5ms (70.2 MB)   |
 | formatting edits | 1 edit          | 21 edits          |
 
 ## twitter
@@ -29,10 +29,10 @@ Note: memory values are RSS (resident set size), shown in megabytes.
 
 | method           | jjpwrgem        | vscode-json       |
 | ---------------- | --------------- | ----------------- |
-| initialize       | 15.1ms (4.6 MB) | 143.5ms (71.6 MB) |
-| diagnostic       | 9.2ms (7.2 MB)  | 528.2ms (81.1 MB) |
-| formatting       | 2.5ms (7.2 MB)  | 55.6ms (80.4 MB)  |
-| formatting edits | 1 edit          | 15480 edits       |
+| initialize       | 12.9ms (4.6 MB) | 165.1ms (71.1 MB) |
+| diagnostic       | 10.0ms (7.4 MB) | 541.8ms (80.9 MB) |
+| formatting       | 2.9ms (7.4 MB)  | 58.3ms (80.1 MB)  |
+| formatting edits | 1 edit          | 15481 edits       |
 
 ## citm catalog
 
@@ -40,12 +40,12 @@ Note: memory values are RSS (resident set size), shown in megabytes.
 
 Note: memory values are RSS (resident set size), shown in megabytes.
 
-| method           | jjpwrgem         | vscode-json        |
-| ---------------- | ---------------- | ------------------ |
-| initialize       | 12.3ms (4.6 MB)  | 139.6ms (71.4 MB)  |
-| diagnostic       | 19.5ms (11.6 MB) | 563.9ms (105.5 MB) |
-| formatting       | 3.5ms (11.7 MB)  | 17.5ms (101.9 MB)  |
-| formatting edits | 1 edit           | 0 edits            |
+| method           | jjpwrgem         | vscode-json       |
+| ---------------- | ---------------- | ----------------- |
+| initialize       | 12.6ms (4.6 MB)  | 152.3ms (71.2 MB) |
+| diagnostic       | 17.1ms (11.0 MB) | 573.3ms (96.0 MB) |
+| formatting       | 4.4ms (10.8 MB)  | 116.7ms (93.9 MB) |
+| formatting edits | 1 edit           | 50468 edits       |
 
 ## canada
 
@@ -55,7 +55,7 @@ Note: memory values are RSS (resident set size), shown in megabytes.
 
 | method           | jjpwrgem         | vscode-json        |
 | ---------------- | ---------------- | ------------------ |
-| initialize       | 12.5ms (4.6 MB)  | 140.5ms (71.2 MB)  |
-| diagnostic       | 34.9ms (21.0 MB) | 579.8ms (124.7 MB) |
-| formatting       | 9.1ms (20.8 MB)  | 350.7ms (122.4 MB) |
-| formatting edits | 1 edit           | 223229 edits       |
+| initialize       | 12.5ms (4.6 MB)  | 147.7ms (71.7 MB)  |
+| diagnostic       | 45.6ms (24.8 MB) | 618.6ms (123.1 MB) |
+| formatting       | 9.8ms (24.7 MB)  | 477.2ms (120.4 MB) |
+| formatting edits | 1 edit           | 223227 edits       |

--- a/crates/cli/main.rs
+++ b/crates/cli/main.rs
@@ -145,7 +145,7 @@ fn check_jsonlines(json: &str, style: Style) -> Output {
 }
 
 fn format_jsonlines(json: &str, style: Style) -> Output {
-    match jsonlines::format(json) {
+    match jsonlines::format(json, LineEnding::Lf) {
         Ok(result) => Output::success(result),
         Err(e) => Output::failure_diagnostic(Diagnostic::from(&e), style),
     }

--- a/crates/lsp/src/backend.rs
+++ b/crates/lsp/src/backend.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use dashmap::DashMap;
 use jjpwrgem_parse::{
     ast::Document,
-    format::{LineEnding, prettify_document},
+    format::{JsonMode, format_document},
 };
 use tower_lsp_server::{Client, LanguageServer, jsonrpc::Result, ls_types::*};
 
@@ -131,7 +131,7 @@ impl LanguageServer for Backend {
             return Ok(None);
         };
 
-        let formatted = prettify_document(document, 80, LineEnding::Lf);
+        let formatted = format_document(document, &JsonMode::default());
         Ok(Some(vec![TextEdit {
             range: FULL_DOCUMENT_RANGE,
             new_text: formatted,

--- a/crates/parse/Cargo.toml
+++ b/crates/parse/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["json", "parser", "formatter", "diagnostics"]
 categories = ["parser-implementations", "text-processing"]
 
 [dependencies]
+bon = "3.9"
 bytes2chars = { workspace = true }
 displaydoc = { workspace = true }
 serde = { version = "1.0.228", optional = true, features = ["derive"] }

--- a/crates/parse/src/format.rs
+++ b/crates/parse/src/format.rs
@@ -6,6 +6,53 @@ pub(crate) mod uglify;
 pub use prettify::{prettify_document, prettify_document_into, prettify_str};
 pub use uglify::{uglify_document, uglify_document_into, uglify_str, uglify_str_into};
 
+use crate::ast::Document;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FormatRequest {
+    Json(JsonMode),
+    Jsonlines(JsonlinesOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonMode {
+    Prettify(PrettifyOptions),
+    Uglify,
+}
+
+#[derive(bon::Builder, Debug, Clone, PartialEq, Eq)]
+pub struct PrettifyOptions {
+    #[builder(default = 80)]
+    pub preferred_width: usize,
+    #[builder(default)]
+    pub line_ending: LineEnding,
+}
+
+#[derive(bon::Builder, Debug, Clone, PartialEq, Eq)]
+pub struct JsonlinesOptions {
+    #[builder(default)]
+    pub line_ending: LineEnding,
+}
+
+impl Default for FormatRequest {
+    fn default() -> Self {
+        Self::Json(JsonMode::default())
+    }
+}
+
+impl Default for JsonMode {
+    fn default() -> Self {
+        Self::Prettify(PrettifyOptions::builder().build())
+    }
+}
+
+pub fn format_document<S: AsRef<str>>(doc: &Document<S>, mode: &JsonMode) -> String {
+    match mode {
+        JsonMode::Prettify(opts) => prettify_document(doc, opts.preferred_width, opts.line_ending),
+        JsonMode::Uglify => uglify_document(doc),
+    }
+}
+
 use crate::tokens::{FALSE, NULL, TRUE};
 
 pub(crate) fn join_into<T, B>(
@@ -24,8 +71,9 @@ pub(crate) fn join_into<T, B>(
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum LineEnding {
+    #[default]
     Lf,
     CrLf,
     Cr,

--- a/crates/parse/src/jsonlines.rs
+++ b/crates/parse/src/jsonlines.rs
@@ -1,7 +1,7 @@
 use crate::{
     Result,
     ast::{Value, parse_at},
-    format::uglify_str_into,
+    format::{LineEnding, uglify_str_into},
 };
 
 #[derive(Debug)]
@@ -50,7 +50,7 @@ pub fn parse(source: &str) -> Result<JsonlinesDocument<&str>> {
     JsonlinesDocument::parse(source)
 }
 
-pub fn format(source: &str) -> Result<String> {
+pub fn format(source: &str, line_ending: LineEnding) -> Result<String> {
     let text = source.strip_suffix('\n').unwrap_or(source);
     let mut lines = text.split('\n');
 
@@ -62,7 +62,7 @@ pub fn format(source: &str) -> Result<String> {
     uglify_str_into(&mut result, line)?;
 
     for line in lines {
-        result.push('\n');
+        result.push_str(line_ending.as_str());
         uglify_str_into(&mut result, line)?;
     }
     Ok(result)

--- a/crates/parse/src/lib.rs
+++ b/crates/parse/src/lib.rs
@@ -11,3 +11,15 @@ mod traverse;
 pub use check::validate_str;
 
 pub use crate::error::{Error, ErrorKind, Result};
+
+pub fn format_str(json: &str, request: &format::FormatRequest) -> Result<String> {
+    match request {
+        format::FormatRequest::Json(mode) => match mode {
+            format::JsonMode::Prettify(opts) => {
+                format::prettify_str(json, opts.preferred_width, opts.line_ending)
+            }
+            format::JsonMode::Uglify => format::uglify_str(json),
+        },
+        format::FormatRequest::Jsonlines(opts) => jsonlines::format(json, opts.line_ending),
+    }
+}

--- a/xtask/src/template.rs
+++ b/xtask/src/template.rs
@@ -386,9 +386,5 @@ pub fn are_readmes_updated() -> anyhow::Result<()> {
     let existing = fs::read_to_string(BYTES2CHARS_README_PATH).unwrap_or_default();
     let generated = inject_pre_rdme(&existing, &bytes2chars_pre_rdme);
     check_readme("crates/bytes2chars/README.md", &existing, &generated)?;
-    if let Some(lsp_bench_rendered) = generate_lsp_bench_readme() {
-        let existing = fs::read_to_string(LSP_BENCH_OUT_PATH_STR).unwrap_or_default();
-        check_readme("benches/lsp/README.md", &existing, &lsp_bench_rendered)?;
-    }
     Ok(())
 }


### PR DESCRIPTION
- update configs to structs to increase portability and reduce breaking changes with new options
- don't require lsp bench to be up to date