### PR TITLE
chore: bump actions to latest

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -3,7 +3,8 @@ min_version = "2026.5.12"
 [settings]
 experimental = true
 lockfile = true
-idiomatic_version_file_enable_tools = ["node", "pnpm"]
+disable_backends = ["asdf"] # doesn't play nice with lockfiles
+idiomatic_version_file_enable_tools = ["node"]
 
 [settings.cargo]
 binstall = true
@@ -12,6 +13,7 @@ binstall = true
 hk = "1.46.0"
 "aqua:apple/pkl" = "0.31.1"
 jq = "1.8.1"
+"aqua:pnpm/pnpm" = "11.5.0"
 
 [hooks]
 postinstall = "hk install --mise"

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -60,6 +60,40 @@ url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-aarch64-apple-darw
 checksum = "sha256:94c7c460d05748524a96583b656e8dec31a11a30ce6a997b9a5b5d8ec4d1b7e7"
 url = "https://github.com/jdx/hk/releases/download/v1.45.0/hk-x86_64-pc-windows-msvc.zip"
 
+[[tools."aqua:pnpm/pnpm"]]
+version = "11.5.0"
+backend = "aqua:pnpm/pnpm"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-arm64"]
+checksum = "sha256:f817841be043e2be465cb8b8c7ddd19dcedf3120214783dc473a6da7f8c84da9"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-linux-arm64.tar.gz"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-arm64-musl"]
+checksum = "sha256:6733e0f4295a09e3465224639d212cb0c01cc438e3db1b2e47d61e49fd3f4d0a"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-linux-arm64-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-x64"]
+checksum = "sha256:d45c4338299cae5b7fcaf5e95294643edb10de98258fc0b1d566ffa00b0c353c"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-linux-x64.tar.gz"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.linux-x64-musl"]
+checksum = "sha256:f114fa068bb5b45472e3389b19722feb9cb47b72ca656fb5a5cbb7d5fbb7ed06"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-linux-x64-musl.tar.gz"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.macos-arm64"]
+checksum = "sha256:966f2ed3587457e1135b7102569b08f21c717f49d5676d63f9435bac9682c45b"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-darwin-arm64.tar.gz"
+provenance = "github-attestations"
+
+[tools."aqua:pnpm/pnpm"."platforms.windows-x64"]
+checksum = "sha256:f85f5c399caa41e2fbce8a2127b69ea4d2ab9b45296756a557b26110d01dcefd"
+url = "https://github.com/pnpm/pnpm/releases/download/v11.5.0/pnpm-win32-x64.zip"
+provenance = "github-attestations"
+
 [[tools.hk]]
 version = "1.46.0"
 backend = "aqua:jdx/hk"
@@ -126,3 +160,7 @@ provenance = "github-attestations"
 checksum = "sha256:23cb60a1354eed6bcc8d9b9735e8c7b388cd1fdcb75726b93bc299ef22dd9334"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-amd64.exe"
 provenance = "github-attestations"
+
+[[tools.pnpm]]
+version = "11.5.0"
+backend = "asdf:pnpm"

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -7,6 +7,6 @@ runs:
     - uses: taiki-e/install-action@e3134ec54b36203e18f2d1e80652058bd078dd91 # v2.77.3
       with:
         tool: cargo-binstall
-    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+    - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: package.json
     - run: pnpm install --ignore-scripts

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -86,12 +86,6 @@
       "automerge": true
     },
     {
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["packageManager"],
-      "matchPackageNames": ["pnpm"],
-      "automerge": true
-    },
-    {
       "matchManagers": ["mise"],
       "matchFileNames": [
         ".config/mise/config.toml",
@@ -145,6 +139,11 @@
       ],
       "groupName": "mise release tools",
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchPackageNames": ["pnpm", "aqua:pnpm/pnpm"],
+      "groupName": "pnpm",
+      "automerge": true
     }
   ],
   "ignorePaths": [

--- a/.github/workflows/host-npm.yml
+++ b/.github/workflows/host-npm.yml
@@ -18,12 +18,12 @@ jobs:
     env:
       PLAN: ${{ inputs.plan }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
@@ -34,7 +34,7 @@ jobs:
           npm pack ./npm-template --pack-destination ./npm
 
       - name: Upload npm package artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.ref_name }}-npm-package.tgz
           path: ./npm/*.tgz

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,13 +20,13 @@ jobs:
       PLAN: ${{ inputs.plan }}
     steps:
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm i -g npm@latest
       - name: Download npm package artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ github.ref_name }}-npm-package.tgz
           path: ./npm


### PR DESCRIPTION
bumps mise action to get auto lockfile installs

Unfortunately idiomatic tools don't seem to show up in the lockfile so adding pnpm as an explicit tool