### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.7.1...jjpwrgem-v0.7.2) - 2026-07-08
+
+### Documentation
+
+- update vscode and LSP perf claims
+- add vscode extension URL
+- add metadata and docs for vscode extension
+
+### Fixed
+
+- *(deps)* update rust deps (minor + patch) ([#393](https://github.com/20jasper/JJPWRGEM/pull/393))
+
 ## [0.7.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.7.0...jjpwrgem-v0.7.1) - 2026-06-06
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,7 +1117,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jjpwrgem"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anstream",
  "bytes2chars",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "jjpwrgem-lsp"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dashmap",
  "jjpwrgem-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jjpwrgem"
 description = "jjpwrgem json parser with really good error messages"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 authors.workspace = true
 keywords = ["parser", "formatter", "json", "linter"]

--- a/crates/lsp/CHANGELOG.md
+++ b/crates/lsp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.2...jjpwrgem-lsp-v0.1.3) - 2026-07-08
+
+### Documentation
+
+- add vscode extension URL
+- update vscode and LSP perf claims
+- add metadata and docs for vscode extension
+
 ## [0.1.1](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.0...jjpwrgem-lsp-v0.1.1) - 2026-05-24
 
 ### Added

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jjpwrgem-lsp"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 description = "JSON language server with rich errors"

--- a/npm-packages/jjpwrgem/npm-shrinkwrap.json
+++ b/npm-packages/jjpwrgem/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "jjpwrgem",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jjpwrgem",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/npm-packages/jjpwrgem/package.json
+++ b/npm-packages/jjpwrgem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jjpwrgem",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "description": "jjpwrgem json parser with really good error messages",
   "keywords": [
@@ -38,7 +38,7 @@
     "node": ">=14",
     "npm": ">=6"
   },
-  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.7.1",
+  "artifactDownloadUrl": "https://github.com/20jasper/jjpwrgem/releases/download/jjpwrgem-v0.7.2",
   "glibcMinimum": {
     "major": 2,
     "series": 35


### PR DESCRIPTION



## 🤖 New release

* `jjpwrgem-lsp`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `jjpwrgem`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `jjpwrgem-lsp`

<blockquote>

## [0.1.3](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-lsp-v0.1.2...jjpwrgem-lsp-v0.1.3) - 2026-07-08

### Documentation

- add vscode extension URL
- update vscode and LSP perf claims
- add metadata and docs for vscode extension
</blockquote>

## `jjpwrgem`

<blockquote>

## [0.7.2](https://github.com/20jasper/JJPWRGEM/compare/jjpwrgem-v0.7.1...jjpwrgem-v0.7.2) - 2026-07-08

### Documentation

- update vscode and LSP perf claims
- add vscode extension URL
- add metadata and docs for vscode extension

### Fixed

- *(deps)* update rust deps (minor + patch) ([#393](https://github.com/20jasper/JJPWRGEM/pull/393))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).